### PR TITLE
Add possibility for devices with names like "xxxNNN.XXX"

### DIFF
--- a/manifests/l2/port.pp
+++ b/manifests/l2/port.pp
@@ -72,10 +72,18 @@ define l23network::l2::port (
       }
     }
     /^([\w\-]+\d+)\.(\d+)/: {
-      $port_vlan_mode = 'eth'
-      $port_vlan_id   = $2
-      $port_vlan_dev  = $1
-      $port_name      = "${1}.${2}"
+      if $vlan_dev == false {
+        # special case for non-vlan devices witn naming like "aaaNNN.XXX"
+        $port_vlan_mode = undef
+        $port_vlan_id   = undef
+        $port_vlan_dev  = undef
+        $port_name      = $port
+      } else {
+        $port_vlan_mode = 'eth'
+        $port_vlan_id   = $2
+        $port_vlan_dev  = $1
+        $port_name      = "${1}.${2}"
+      }
     }
     default: {
       $port_vlan_mode = undef

--- a/spec/classes/ifconfig_for_infiniband__spec.rb
+++ b/spec/classes/ifconfig_for_infiniband__spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe 'l23network::examples::run_network_scheme', :type => :class do
+let(:network_scheme) do
+<<eof
+---
+network_scheme:
+  version: 1.1
+  provider: lnx
+  interfaces:
+    ib2: {}
+  transformations:
+    - action:   add-port
+      name:     ib2.8001
+      vlan_dev: false
+  endpoints:
+    ib2.8001:
+      IP:
+        - 192.168.101.3/24
+  roles: {}
+eof
+end
+
+  context 'network scheme with endpoint, which contained additionat routes' do
+    let(:title) { 'empty network scheme' }
+    let(:facts) {
+      {
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :kernel => 'Linux',
+        :l23_os => 'ubuntu',
+        :l3_fqdn_hostname => 'stupid_hostname',
+      }
+    }
+
+    let(:params) do {
+      :settings_yaml => network_scheme,
+    } end
+
+    it do
+      should compile
+    end
+
+    it do
+      should contain_l2_port('ib2')
+    end
+
+    it do
+      should contain_l2_port('ib2.8001').with({
+        'vlan_dev'  => nil,
+        'vlan_id'   => nil,
+        'vlan_mode' => nil,
+      })
+    end
+
+    it do
+      should contain_l3_ifconfig('ib2.8001').with({
+        'ipaddr' => '192.168.101.3/24',
+      })
+    end
+
+  end
+
+end
+
+###

--- a/spec/defines/l2_port__infiniband__spec.rb
+++ b/spec/defines/l2_port__infiniband__spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe 'l23network::l2::port', :type => :define do
+  let(:title) { 'Spec for l23network::l2::port with workaround for IB' }
+  let(:facts) { {
+    :osfamily => 'Debian',
+    :operatingsystem => 'Ubuntu',
+    :kernel => 'Linux',
+    :l23_os => 'ubuntu',
+    :l3_fqdn_hostname => 'stupid_hostname',
+  } }
+  let(:pre_condition) { [
+    "class {'l23network': }"
+  ] }
+
+
+  context 'Infiniband parent' do
+    let(:params) do
+      {
+        :name => 'ib0',
+      }
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_l23_stored_config('ib0').with({
+        'ensure'  => 'present',
+        'use_ovs' => nil,
+        'if_type' => nil,
+        'method'  => nil,
+        'ipaddr'  => nil,
+        'gateway' => nil,
+          })
+    end
+
+    it do
+      should contain_l2_port('ib0').with({
+        'ensure'  => 'present',
+      }).that_requires('L23_stored_config[ib0]')
+    end
+  end
+
+  context 'Infiniband subinterface' do
+    let(:params) do
+      {
+        :name     => 'ib0.8000',
+        :vlan_dev => false
+      }
+    end
+
+    it do
+      should compile
+    end
+
+    it do
+      should contain_l23_stored_config('ib0.8000').with({
+        'ensure'    => 'present',
+        'if_type'   => nil,
+        'use_ovs'   => nil,
+        'method'    => nil,
+        'ipaddr'    => nil,
+        'gateway'   => nil,
+        'vlan_id'   => nil,
+        'vlan_dev'  => nil,
+        'vlan_mode' => nil
+      })
+    end
+
+    it do
+      should contain_l2_port('ib0.8000').with({
+        'ensure'    => 'present',
+        'vlan_id'   => nil,
+        'vlan_dev'  => nil,
+        'vlan_mode' => nil
+      }).that_requires("L23_stored_config[ib0.8000]")
+    end
+  end
+
+
+end
+# vim: set ts=2 sw=2 et


### PR DESCRIPTION
to be not an 802.1q vlan interfaces
by defining

    vlan_dev: false

in network scheme

Closes: #35