### PR TITLE
Fix deprecated method for rspec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ InstalledFiles
 lib/bundler/man
 pkg
 rdoc
+spec/fixtures
 spec/reports
 test/tmp
 test/version_tmp

--- a/spec/functions/array_or_string_to_array__spec.rb
+++ b/spec/functions/array_or_string_to_array__spec.rb
@@ -4,29 +4,29 @@ describe 'array_or_string_to_array' do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'should exist' do
-    Puppet::Parser::Functions.function('array_or_string_to_array').should == 'function_array_or_string_to_array'
+    expect(Puppet::Parser::Functions.function('array_or_string_to_array')).to eq('function_array_or_string_to_array')
   end
 
   it 'should throw an error on invalid types' do
-    lambda {
+    expect {
       scope.function_array_or_string_to_array([{:foo => :bar}])
-    }.should(raise_error(Puppet::ParseError))
+    }.to(raise_error(Puppet::ParseError))
   end
 
   it 'should throw an error on invalid arguments number' do
-    lambda {
+    expect {
       scope.function_array_or_string_to_array([])
-    }.should(raise_error(Puppet::ParseError))
-    lambda {
+    }.to(raise_error(Puppet::ParseError))
+    expect {
       scope.function_array_or_string_to_array([[1,2],[3,4]])
-    }.should(raise_error(Puppet::ParseError))
+    }.to(raise_error(Puppet::ParseError))
   end
 
   it 'should return array if given array' do
-    scope.function_array_or_string_to_array([[1,2,3,4,5,6,7,8,9]]).should == [1,2,3,4,5,6,7,8,9]
+    expect(scope.function_array_or_string_to_array([[1,2,3,4,5,6,7,8,9]])).to eq([1,2,3,4,5,6,7,8,9])
   end
 
   it 'should return array of strings if given string with separators' do
-    scope.function_array_or_string_to_array(['1,2,3,4,5:6,7 8,9']).should == ['1','2','3','4','5','6','7','8','9']
+    expect(scope.function_array_or_string_to_array(['1,2,3,4,5:6,7 8,9'])).to eq(['1','2','3','4','5','6','7','8','9'])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,11 @@ if Puppet.version < '4.0.0'
   end
 end
 
+Puppet::Util::Log.level = :debug
+Puppet::Util::Log.newdestination(:console)
+
 RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.mock_with(:mocha)
 end


### PR DESCRIPTION
Also:
* add to .gitignore prevention to store temporary fixtures and
required modules
* enable some of puppet debug output to the test console

Closes: #73