### PR TITLE
Default route restoring and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .bundle
 .config
 *.lock
+*.diff
 coverage
 InstalledFiles
 lib/bundler/man

--- a/manifests/l2/port.pp
+++ b/manifests/l2/port.pp
@@ -32,6 +32,7 @@ define l23network::l2::port (
   $ensure                = present,
   $use_ovs               = $::l23network::use_ovs,
   $port                  = $name,
+  $if_type               = undef,
   $bridge                = undef,
   $onboot                = undef,
   $vlan_id               = undef,  # actually only for OVS workflow
@@ -112,9 +113,14 @@ define l23network::l2::port (
     if ! defined(L23_stored_config[$port_name]) {
       l23_stored_config { $port_name: }
     }
+    # if_type is not used on debian based distros at all
+    # on redhat based - is not strictly required. If the TYPE directive is not set,
+    # the device is treated as an Ethernet device
+    # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/s2-networkscripts-interfaces_network-bridge.html
+
     L23_stored_config <| title == $port_name |> {
       ensure          => $ensure,
-      if_type         => 'ethernet',
+      if_type         => $if_type,
       bridge          => $bridge,
       vlan_id         => $port_vlan_id,
       vlan_dev        => $port_vlan_dev,

--- a/spec/defines/ifconfig__dhcp__spec.rb
+++ b/spec/defines/ifconfig__dhcp__spec.rb
@@ -29,7 +29,6 @@ describe 'l23network::l3::ifconfig', :type => :define do
         'method'         => 'dhcp',
         'ipaddr'         => 'dhcp',
         'gateway'        => nil,
-        'use_ovs'        => nil,
       })
     end
 

--- a/spec/defines/ifconfig__spec.rb
+++ b/spec/defines/ifconfig__spec.rb
@@ -29,7 +29,6 @@ describe 'l23network::l3::ifconfig', :type => :define do
         'method'         => 'manual',
         'ipaddr'         => 'none',
         'gateway'        => nil,
-        'use_ovs'        => nil,
       })
     end
 

--- a/spec/defines/l2_bond__spec.rb
+++ b/spec/defines/l2_bond__spec.rb
@@ -52,7 +52,7 @@ describe 'l23network::l2::bond', :type => :define do
       it do
         should contain_l23_stored_config(slave).with({
           'ensure'      => 'present',
-          'if_type'     => 'ethernet',
+          'if_type'     => nil,
           'bond_master' => 'bond0',
         })
       end

--- a/spec/defines/l2_port__spec.rb
+++ b/spec/defines/l2_port__spec.rb
@@ -26,12 +26,14 @@ describe 'l23network::l2::port', :type => :define do
     end
 
     it do
-      should contain_l23_stored_config('eth4').only_with({
+      should contain_l23_stored_config('eth4').with({
+        'ensure'  => 'present',
         'use_ovs' => nil,
+        'if_type' => nil,
         'method'  => nil,
         'ipaddr'  => nil,
         'gateway' => nil,
-      })
+          })
     end
 
     it do
@@ -53,7 +55,9 @@ describe 'l23network::l2::port', :type => :define do
     end
 
     it do
-      should contain_l23_stored_config('eth4.102').only_with({
+      should contain_l23_stored_config('eth4.102').with({
+        'ensure'    => 'present',
+        'if_type'   => nil,
         'use_ovs'   => nil,
         'method'    => nil,
         'ipaddr'    => nil,
@@ -66,7 +70,7 @@ describe 'l23network::l2::port', :type => :define do
 
     it do
       should contain_l2_port('eth4.102').with({
-        'ensure'  => 'present',
+        'ensure'    => 'present',
         'vlan_id'   => '102',
         'vlan_dev'  => 'eth4',
         'vlan_mode' => 'eth'
@@ -88,7 +92,9 @@ describe 'l23network::l2::port', :type => :define do
     end
 
     it do
-      should contain_l23_stored_config('vlan102').only_with({
+      should contain_l23_stored_config('vlan102').with({
+        'ensure'    => 'present',
+        'if_type'   => nil,
         'use_ovs'   => nil,
         'method'    => nil,
         'ipaddr'    => nil,
@@ -101,7 +107,7 @@ describe 'l23network::l2::port', :type => :define do
 
     it do
       should contain_l2_port('vlan102').with({
-        'ensure'  => 'present',
+        'ensure'    => 'present',
         'vlan_id'   => '102',
         'vlan_dev'  => 'eth4',
         'vlan_mode' => 'vlan'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 
+PROJECT_ROOT = File.expand_path('..', File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(PROJECT_ROOT, "lib"))
+
 # Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
 if Puppet.version < '4.0.0'
   Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|

--- a/spec/unit/puppet/provider/l23_stored_config_centos6_spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config_centos6_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos6) do
+
+  let(:input_data) do
+    {
+      :eth1 => {
+                 :name     => "eth1",
+                 :method   => "static",
+                 :ipaddr   => "169.254.0.1/24",
+                 :provider => "lnx_centos6",
+               },
+      :eth2 => {
+                 :name           => "eth2",
+                 :onboot         => "yes",
+                 :method         => "static",
+                 :ipaddr         => "192.168.22.3/24",
+                 :gateway        => "192.168.22.1",
+                 :gateway_metric => "231",
+                 :provider       => "lnx_centos6",
+               },
+      :'br-storage' => {
+                 :name     => "br-storage",
+                 :onboot   => "yes",
+                 :method   => "static",
+                 :ipaddr   => "192.168.55.33/24",
+                 :provider => "lnx_centos6",
+                 :routes   => { '10.109.22.0/24' => { 'gateway' => '192.168.55.54', 'destination' => '10.109.22.0/24' } }
+               }
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'lnx_centos6_spec')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "the method property" do
+    context 'when dhcp' do
+      let(:data) { subject.class.parse_file('eth0', fixture_data('ifcfg-eth0'))[0] }
+      it { expect(data[:method]).to eq :dhcp }
+    end
+  end
+
+  context "when formatting resources" do
+
+    context 'with test interface eth1' do
+      subject { providers[:eth1] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      it { expect(data).to match %r(DEVICE=eth1) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=169\.254\.0\.1) }
+      it { expect(data).not_to match %r(GATEWAY=.*) }
+      it { expect(data).not_to match %r(METRIC=.*) }
+      it { expect(data).to match %r(PREFIX=24) }
+
+      it 'should not remove GATEWAY from /etc/sysconfig/network' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+      it 'should not write route to /etc/sysconfig/network-scripts/route-eth1' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+    end
+
+    context 'with test interface eth2 with default gateway' do
+      subject { providers[:eth2] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      let(:content) { "NETWORKING=yes\nGATEWAY=5.5.5.5\n" }
+      let(:file) { '/etc/sysconfig/network' }
+
+      before(:each) do
+        subject.class.stubs(:read_file).with(file).returns content
+        subject.class.stubs(:write_file).returns true
+      end
+
+      it { expect(data).to match %r(DEVICE=eth2) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=192\.168\.22\.3) }
+      it { expect(data).to match %r(GATEWAY=192\.168\.22\.1) }
+      it { expect(data).to match %r(METRIC=231) }
+      it { expect(data).to match %r(PREFIX=24) }
+
+      it 'should remove GATEWAY from /etc/sysconfig/network' do
+        subject.class.expects(:write_file).with(file, "NETWORKING=yes\n").returns true
+        data
+      end
+      it 'should not write route to /etc/sysconfig/network-scripts/route-eth2' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+    end
+
+    context 'with test interface br-storage with routes' do
+      subject { providers[:'br-storage'] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      let(:content) { "10.109.22.0/24 via 192.168.55.54 dev br-storage\n" }
+      let(:file) { '/etc/sysconfig/network-scripts/route-br-storage' }
+
+      before(:each) do
+        subject.class.stubs(:write_file).returns true
+      end
+
+      it { expect(data).to match %r(DEVICE=br-storage) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=192\.168\.55\.33) }
+      it { expect(data).to match %r(PREFIX=24) }
+      it { expect(data).not_to match %r(ROUTES=.*) }
+
+      it 'should write route to /etc/sysconfig/network-scripts/route-br-storage' do
+        subject.class.expects(:write_file).with(file, content).returns true
+        data
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
* Remove default gateway from global network file
* Add support of metric for default gateway
* Fix interface type changing in cases if we call l3::ifconfig for bridge
* Add and fix tests
* Fix correct default route restoring

Author: Stanislav Makar <smakar@mirantis.com>
FUEL-Change-Id: Id805f7fdc76e6f7384efa7509702026a3c13eb2b
FUEL-Change-Id: Ieb7526878a21ace03cc5fe76512a29be0ba23ba4

Closes: #20