### PR TITLE
Fix default route overwriting problem

### DIFF
--- a/lib/puppet/parser/functions/generate_network_config.rb
+++ b/lib/puppet/parser/functions/generate_network_config.rb
@@ -336,6 +336,17 @@ Puppet::Parser::Functions::newfunction(:generate_network_config, :type => :rvalu
             #todo(sv): more powerfull handler for 'nil' properties
           end
         end
+        #Clear default gateway
+        if resource_properties['gateway']
+          l3_resource_properties = { 'ensure' => 'absent', 'destination' => 'default' }
+          l3_resource_properties['metric'] = resource_properties['gateway_metric'] if resource_properties['gateway_metric']
+          gateway_name = L23network.get_route_resource_name('default', l3_resource_properties['metric'])
+          if previous
+             l3_resource_properties['require'] = [previous]
+             previous = "l3_clear_route[#{gateway_name}]"
+          end
+          function_create_resources(['l3_clear_route', { gateway_name => l3_resource_properties }])
+        end
         resource_properties['require'] = [previous] if previous
         # # set ipaddresses
         # #if endpoints[endpoint_name][:IP].empty?

--- a/lib/puppet/provider/l3_clear_route/lnx.rb
+++ b/lib/puppet/provider/l3_clear_route/lnx.rb
@@ -1,0 +1,103 @@
+require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/lnx_base')
+
+Puppet::Type.type(:l3_clear_route).provide(:lnx) do
+  defaultfor :osfamily   => :linux
+  commands   :ip         => 'ip'
+
+
+  def self.prefetch(resources)
+    interfaces = instances
+    resources.keys.each do |name|
+      if provider = interfaces.find{ |ii| ii.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def self.get_routes
+    # return array of hashes -- all defined routes.
+    rv = []
+    # cat /proc/net/route returns information about routing table in format:
+    # Iface Destination Gateway   Flags RefCnt Use Metric Mask    MTU Window IRTT
+    # eth0  00000000    0101010A  0003   0      0    0    00000000 0    0     0
+    # eth0  0001010A    00000000  0001   0      0    0    00FFFFFF 0    0     0
+    File.open('/proc/net/route').readlines.reject{|l| l.match(/^[Ii]face.+/) or l.match(/^(\r\n|\n|\s*)$|^$/)}.map{|l| l.split(/\s+/)}.each do |line|
+      #https://github.com/kwilczynski/facter-facts/blob/master/default_gateway.rb
+      iface = line[0]
+      metric = line[6]
+      # whether gateway is default
+      if line[1] == '00000000'
+        dest = 'default'
+        dest_addr = nil
+        mask = nil
+        route_type = 'default'
+      else
+        dest_addr = [line[1]].pack('H*').unpack('C4').reverse.join('.')
+        mask = [line[7]].pack('H*').unpack('B*')[0].count('1')
+        dest = "#{dest_addr}/#{mask}"
+      end
+      rv << {
+        :destination    => dest,
+        :metric         => metric.to_i,
+      }
+    end
+    # this sort need for prioritize routes by metrics
+    return rv.sort_by{|r| r[:metric]||0}
+  end
+
+  def self.instances
+    rv = []
+    routes = get_routes()
+    routes.each do |route|
+      name = L23network.get_route_resource_name(route[:destination], route[:metric])
+      props = {
+        :ensure         => :present,
+        :name           => name,
+      }
+      props.merge! route
+      props.delete(:metric) if props[:metric] == 0
+      debug("PREFETCHED properties for '#{name}': #{props}")
+      rv << new(props)
+    end
+    return rv
+  end
+
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    info("\n Does not support 'ensure=present' \n It could be 'ensure=absent' ONLY!!! ")
+  end
+
+  def destroy
+    debug("DESTROY resource: #{@resource}")
+    cmd = ['--force', 'route', 'del', @resource[:destination]]
+    cmd << ['metric', @resource[:metric]] if @resource[:metric] != :absent && @resource[:metric].to_i > 0
+    ip(cmd)
+    @property_hash.clear
+  end
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+    @old_property_hash = {}
+    @old_property_hash.merge! @property_hash
+  end
+  #-----------------------------------------------------------------
+  def destination
+    @property_hash[:destination] || :absent
+  end
+  def destination=(val)
+    @property_flush[:destination] = val
+  end
+
+  def metric
+    @property_hash[:metric] || :absent
+  end
+  def metric=(val)
+    @property_flush[:metric] = val
+  end
+end
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l3_ifconfig/lnx.rb
+++ b/lib/puppet/provider/l3_ifconfig/lnx.rb
@@ -129,7 +129,7 @@ Puppet::Type.type(:l3_ifconfig).provide(:lnx) do
       end
 
       if !@property_flush[:gateway].nil? or !@property_flush[:gateway_metric].nil?
-        # clean all default gateways for this interface with any metrics
+        # clean all default gateways for *THIS* interface (with any metrics)
         cmdline = ['route', 'del', 'default', 'dev', @resource[:interface]]
 
         while true
@@ -142,8 +142,14 @@ Puppet::Type.type(:l3_ifconfig).provide(:lnx) do
             break
           end
         end
-        # add new route
+
+        # add new default route
         if @resource[:gateway] != :absent
+          # WARNING!!!
+          # We shouldn't use 'ip route replace .....' here
+          # because *replace* can change gateway in context of another interface.
+          # Changing (or removing) gateway for another interface leads to some heavy-diagnostic cases.
+          # For manipulate gateways without interface context -- should be used l3_route resource.
           cmdline = ['route', 'add', 'default', 'via', @resource[:gateway], 'dev', @resource[:interface]]
           if ![nil, :absent].include?(@property_flush[:gateway_metric]) and @property_flush[:gateway_metric].to_i > 0
             cmdline << ['metric', @property_flush[:gateway_metric]]
@@ -151,16 +157,13 @@ Puppet::Type.type(:l3_ifconfig).provide(:lnx) do
           begin
             rv = iproute(cmdline)
           rescue
-            warn("!!! Iproute can't setup new gateway.\n!!! May be you already have default gateway with same metric:")
+            warn("!!! Iproute can not setup new gateway.\n!!! May be default gateway with same metric already exists:")
             rv = iproute('-f', 'inet', 'route', 'show')
             warn("#{rv}\n\n")
           end
         end
       end
 
-      # if ! @property_flush[:onboot].nil?
-      #   iproute('link', 'set', 'dev', @resource[:interface], 'up')
-      # end
       @property_hash = resource.to_hash
     end
   end

--- a/lib/puppet/type/l3_clear_route.rb
+++ b/lib/puppet/type/l3_clear_route.rb
@@ -1,0 +1,51 @@
+# type for clearing runtime routes.
+
+Puppet::Type.newtype(:l3_clear_route) do
+    @doc = "Clear routes for destination with specified metric."
+    desc @doc
+
+    ensurable
+
+    newparam(:name) # workarround for following error:
+    # Error 400 on SERVER: Could not render to pson: undefined method `merge' for []:Array
+    # http://projects.puppetlabs.com/issues/5220
+
+
+    newproperty(:destination) do
+      desc "Destination network"
+      validate do |val|
+        val.strip!
+        if val.to_s.downcase != 'default'
+          raise ArgumentError, "Invalid IP address: '#{val}'" if \
+            not val.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(\/(\d{1,2}))?$/) \
+            or not ($1.to_i >= 0  and  $1.to_i <= 255) \
+            or not ($2.to_i >= 0  and  $2.to_i <= 255) \
+            or not ($3.to_i >= 0  and  $3.to_i <= 255) \
+            or not ($4.to_i >= 0  and  $4.to_i <= 255) \
+            or not ($6.to_i >= 0  and  $6.to_i <= 32)
+        end
+      end
+
+    end
+
+    newproperty(:metric) do
+      desc "Route metric"
+      newvalues(/^\d+$/, :absent, :none, :undef, :nil)
+      aliasvalue(:none,  :absent)
+      aliasvalue(:undef, :absent)
+      aliasvalue(:nil,   :absent)
+      aliasvalue(0,      :absent)
+      validate do |val|
+        min_metric = 0
+        max_metric = 65535
+        if ! (val.to_s == 'absent' or (min_metric .. max_metric).include?(val.to_i))
+          raise ArgumentError, "'#{val}' is not a valid metric (must be a integer value in range (#{min_metric} .. #{max_metric})"
+        end
+      end
+      munge do |val|
+        ((val == :absent)  ?  :absent  :  val.to_i)
+      end
+    end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/classes/empty_network_scheme__spec.rb
+++ b/spec/classes/empty_network_scheme__spec.rb
@@ -32,8 +32,12 @@ eof
       should compile
     end
 
+    it 'should not contain l3_clear_route' do
+      should_not contain_l3_clear_route('default').with ({ 'ensure'  => 'absent' })
+    end
+
   end
 
 end
 
-###
+# vim: set ts=2 sw=2 et :

--- a/spec/classes/ifconfig_with_additional_routes__spec.rb
+++ b/spec/classes/ifconfig_with_additional_routes__spec.rb
@@ -102,6 +102,11 @@ end
         })
       end
     end
+
+    it 'should contain l3_clear_route' do
+      should_not contain_l3_clear_route('default').with ({ 'ensure'  => 'absent', 'metric' => 'default' })
+    end
+
   end
 
 end

--- a/spec/classes/ifconfig_with_gateway_spec.rb
+++ b/spec/classes/ifconfig_with_gateway_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe 'l23network::examples::run_network_scheme', :type => :class do
+let(:network_scheme) do
+<<eof
+---
+network_scheme:
+  version: 1.1
+  provider: lnx
+  interfaces:
+    eth2: {}
+  transformations:
+    - action: add-port
+      name:   eth2
+    - action: add-port
+      name:   eth3
+  endpoints:
+    eth2:
+      IP:
+        - 192.168.101.3/24
+      gateway: 192.168.101.1
+    eth3:
+      IP:
+        - 172.16.55.34/24
+      gateway: 172.16.55.1
+      gateway_metric: 88
+  roles: {}
+eof
+end
+
+  context 'network scheme with endpoint, which contained gateway' do
+    let(:title) { 'empty network scheme' }
+    let(:facts) {
+      {
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :kernel => 'Linux',
+        :l23_os => 'ubuntu',
+        :l3_fqdn_hostname => 'stupid_hostname',
+      }
+    }
+
+    let(:params) do {
+      :settings_yaml => network_scheme,
+    } end
+
+    it do
+      should compile
+    end
+
+    it do
+      should contain_l2_port('eth2')
+    end
+
+    it do
+      should contain_l3_ifconfig('eth2').with({
+        'ipaddr'  => '192.168.101.3/24',
+        'gateway' => '192.168.101.1',
+      })
+    end
+
+    it do
+      should contain_l3_ifconfig('eth3').with({
+        'ipaddr'         => '172.16.55.34/24',
+        'gateway'        => '172.16.55.1',
+        'gateway_metric' => '88',
+      })
+    end
+
+
+    it do
+      should contain_l3_clear_route('default').with ({ 'ensure'  => 'absent', 'destination' => 'default' })
+    end
+
+    it do
+      should contain_l3_clear_route('default,metric:88').with ({ 'ensure'  => 'absent', 'destination' => 'default' })
+    end
+
+  end
+
+end
+
+###


### PR DESCRIPTION
* Add simple puppet resource which clear all default gateways
  before creating l3_ifconfig resources
* Add warnings to prevent from using 'ip route replace...'
  command in context of interface setup

Author	Stanislav Makar <smakar@mirantis.com>
FUEL-Change-Id: Ifa73c0a9a4f4df542ea8437b9894c3dce5cfee7e

Closes: #28