### PR TITLE
Set mtu for internal networks according to segmentation type

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 -f doc
---format progress

--- a/lib/puppet/parser/functions/get_transformation_property.rb
+++ b/lib/puppet/parser/functions/get_transformation_property.rb
@@ -1,0 +1,65 @@
+require 'puppetx/l23_network_scheme'
+
+Puppet::Parser::Functions::newfunction(:get_transformation_property, :type => :rvalue, :doc => <<-EOS
+    This function gets an endpoint properties from transformations --
+    and returns information about the selected property
+
+    ex: get_transformation_property('mtu','eth0')
+
+    You can use following modes:
+      mtu -- mtu value for the selected transformation.
+
+    Returns NIL if a device is not found or mtu is not set
+
+    EOS
+  ) do |argv|
+  if argv.size > 1
+    mode = argv[0].to_s().upcase()
+    argv.shift
+  else
+      raise(Puppet::ParseError, "get_transformation_property(...): Wrong number of arguments.")
+  end
+
+  cfg = L23network::Scheme.get_config(lookupvar('l3_fqdn_hostname'))
+  if cfg.nil?
+    raise(Puppet::ParseError, "get_transformation_property(...): You must call prepare_network_config(...) first!")
+  end
+
+  if !cfg[:roles] || !cfg[:endpoints] || cfg[:roles].class.to_s() != "Hash" || cfg[:endpoints].class.to_s() != "Hash"
+      raise(Puppet::ParseError, "get_transformation_property(...): Invalid cfg_hash format.")
+  end
+
+  transforms = cfg[:transformations]
+  ifaces = cfg[:interfaces]
+  all_ifaces = ifaces.keys.map(&:to_s)
+  devices = argv.flatten
+  mtu = []
+
+  rv = nil
+
+  case mode
+    when 'MTU'
+      devices.each do |device|
+        if all_ifaces.include? device and ifaces[device.to_sym][:mtu] != nil
+          mtu.push(ifaces[device.to_sym][:mtu])
+        else
+          for i in 0..transforms.size-1 do
+            transform = cfg[:transformations][i]
+            if transform[:name] == device and transform[:mtu] != nil
+              mtu.push(transform[:mtu])
+            end
+          end
+        end
+        if mtu.empty?
+          Puppet::debug("get_transformation_property(...): MTU value is not set for interface '#{device}'.")
+          rv = nil
+        else
+          rv = mtu.min
+        end
+      end
+  end
+
+  rv
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppetx/l23_network_scheme.rb
+++ b/lib/puppetx/l23_network_scheme.rb
@@ -7,6 +7,36 @@ module L23network
     def self.get_config(h)
       @network_scheme_hash[h.to_sym]
     end
+    def self.get_phys_dev_by_endpoint(endpoint, interfaces, transformations)
+      rv = []
+      all_ifaces = interfaces.keys.map(&:to_s)
+      ifaces = []
+
+      if all_ifaces.include? endpoint
+        ifaces.push(endpoint)
+        return ifaces
+      end
+
+      for i in 0..transformations.size-1  do
+        transform = transformations[i]
+        if transform[:name] != nil and transform[:name].include? endpoint
+          if transform[:vlandev] != nil
+            ifaces.push(transform[:vlandev])
+          else
+            endpoint = transform[:name].split(".")[0]
+            if all_ifaces.include? endpoint
+              ifaces.push(endpoint.to_s)
+            end
+          end
+        elsif transform[:bridge] == endpoint
+          ifaces.push(transform[:name].split(".")[0])
+        elsif transform[:bridges] != nil and transform[:bridges][0] == endpoint
+          endpoint = transform[:bridges][1]
+          ifaces.push(get_phys_dev_by_endpoint(endpoint, interfaces, transformations))
+        end
+      end
+      return ifaces.flatten.uniq
+    end
   end
 end
 # vim: set ts=2 sw=2 et :

--- a/spec/functions/get_network_role_property__phys_dev__spec.rb
+++ b/spec/functions/get_network_role_property__phys_dev__spec.rb
@@ -1,0 +1,149 @@
+require 'spec_helper'
+require 'yaml'
+require 'puppetx/l23_hash_tools'
+
+describe Puppet::Parser::Functions.function(:get_network_role_property) do
+let(:network_scheme) do
+<<eof
+---
+  version: 1.1
+  provider: lnx
+  interfaces:
+    eth0:
+      mtu: 2048
+    eth1:
+      mtu: 999
+    eth2: {}
+    eth3: {}
+    eth4: {}
+  transformations:
+    - action: add-br
+      name: br-storage
+    - action: add-br
+      name: br-ex
+    - action: add-br
+      name: br-mgmt
+    - action: add-port
+      name: eth4
+      mtu: 777
+    - action: add-port
+      name: eth1.101
+      bridge: br-mgmt
+    - action: add-bond
+      name: bond0
+      bridge: br-storage
+      interfaces:
+        - eth2
+        - eth3
+      mtu: 4000
+      bond_properties:
+        mode: balance-rr
+      interface_properties:
+        mtu: 9000
+        vendor_specific:
+          disable_offloading: true
+    - action: add-port
+      name: bond0.102
+      bridge: br-ex
+    - action: add-br
+      name: br-floating
+      provider: ovs
+    - action: add-patch
+      bridges:
+      - br-floating
+      - br-ex
+      provider: ovs
+    - action: add-br
+      name: br-prv
+      provider: ovs
+    - action: add-patch
+      bridges:
+      - br-prv
+      - br-storage
+      provider: ovs
+  endpoints:
+    eth0:
+      IP: 'none'
+    eth4:
+      IP: 'none'
+    br-ex:
+      gateway: 10.1.3.1
+      IP:
+        - '10.1.3.11/24'
+    br-storage:
+      IP:
+        - '10.1.2.11/24'
+    br-mgmt:
+      IP:
+        - '10.1.1.11/24'
+    br-floating:
+      IP: none
+    br-prv:
+      IP: none
+  roles:
+    admin: eth0
+    ex: br-ex
+    management: br-mgmt
+    storage: br-storage
+    neutron/floating: br-floating
+    neutron/private: br-prv
+    xxx: eth4
+eof
+end
+
+
+
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  subject do
+    function_name = Puppet::Parser::Functions.function(:get_network_role_property)
+    scope.method(function_name)
+  end
+
+  context "get_network_role_property('**something_role**', 'phys_dev') usage" do
+    before(:each) do
+      scope.stubs(:lookupvar).with('l3_fqdn_hostname').returns('node1.tld')
+      L23network::Scheme.set_config(
+        scope.lookupvar('l3_fqdn_hostname'),
+        L23network.sanitize_keys_in_hash(YAML.load(network_scheme))
+      )
+    end
+
+    it 'should exist' do
+      subject == Puppet::Parser::Functions.function(:get_network_role_property)
+    end
+
+    it 'should return physical device name for "management" network role (just subinterface)' do
+      should run.with_params('management', 'phys_dev').and_return(["eth1"])
+    end
+
+    it 'should return physical device name for "ex" network role (subinterface of bond)' do
+      should run.with_params('ex', 'phys_dev').and_return(["bond0", "eth2", "eth3"])
+    end
+
+    it 'should return physical device name for "floating" network role (OVS-bridge, connected by patch to LNX bridge)' do
+      should run.with_params('neutron/floating', 'phys_dev').and_return(["bond0", "eth2", "eth3"])
+    end
+
+    it 'should return physical device name for "private" network role' do
+      should run.with_params('neutron/private', 'phys_dev').and_return(["bond0", "eth2", "eth3"])
+    end
+
+    it 'should return physical device name for "storage" network role (bond, without tag)' do
+      should run.with_params('storage', 'phys_dev').and_return(["bond0", "eth2", "eth3"])
+    end
+
+    it 'should return physical device name for "admin" network role (just interface has IP address)' do
+      should run.with_params('admin', 'phys_dev').and_return(['eth0'])
+    end
+
+    it 'should return physical device name for untagged interface with simple transformation' do
+      should run.with_params('xxx', 'phys_dev').and_return(['eth4'])
+    end
+
+    it 'should return NIL for "non-existent" network role' do
+      should run.with_params('non-existent', 'phys_dev').and_return(nil)
+    end
+  end
+
+end

--- a/spec/functions/get_network_role_property__spec.rb
+++ b/spec/functions/get_network_role_property__spec.rb
@@ -13,6 +13,15 @@ describe Puppet::Parser::Functions.function(:get_network_role_property) do
       #Puppet::Parser::Scope.any_instance.stubs(:lookupvar).with('l3_fqdn_hostname').returns('node1.tld')
       scope.stubs(:lookupvar).with('l3_fqdn_hostname').returns('node1.tld')
       L23network::Scheme.set_config(scope.lookupvar('l3_fqdn_hostname'), {
+        :transformations => [ {
+          :bridge => 'br-ex',
+          :name => 'bond0',
+          :mtu => 1450,
+          :interfaces => ["eth1", "eth2"],
+        }, ],
+        :interfaces => {
+          :eth0 => {},
+        },
         :endpoints => {
           :eth0 => {:IP => 'dhcp'},
           :"br-ex" => {
@@ -61,6 +70,10 @@ describe Puppet::Parser::Functions.function(:get_network_role_property) do
       should run.with_params('management', 'ipaddr_netmask_pair').and_return(['10.20.1.11','255.255.255.128'])
     end
 
+    it 'should return physical device name for "ex" network role' do
+      should run.with_params('ex', 'phys_dev').and_return(["bond0", "eth1", "eth2"])
+    end
+
     it 'should return NIL for "admin" network role' do
       should run.with_params('admin', 'netmask').and_return(nil)
     end
@@ -72,6 +85,9 @@ describe Puppet::Parser::Functions.function(:get_network_role_property) do
     end
     it 'should return NIL for "admin" network role' do
       should run.with_params('admin', 'ipaddr_netmask_pair').and_return(nil)
+    end
+    it 'should return NIL for "admin" network role' do
+      should run.with_params('admin', 'phys_dev').and_return(nil)
     end
   end
 

--- a/spec/functions/get_transformation_property__spec.rb
+++ b/spec/functions/get_transformation_property__spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+require 'yaml'
+require 'puppetx/l23_hash_tools'
+
+describe Puppet::Parser::Functions.function(:get_transformation_property) do
+let(:network_scheme) do
+<<eof
+---
+  version: 1.1
+  provider: lnx
+  interfaces:
+    eth0:
+      mtu: 2048
+    eth1:
+      mtu: 999
+    eth2:
+      mtu: 1024
+    eth3: {}
+  transformations:
+    - action: add-br
+      name: br-storage
+    - action: add-br
+      name: br-ex
+    - action: add-br
+      name: br-mgmt
+    - action: add-port
+      name: eth1.101
+      bridge: br-mgmt
+    - action: add-bond
+      name: bond0
+      bridge: br-storage
+      interfaces:
+        - eth2
+        - eth3
+      mtu: 4000
+      bond_properties:
+        mode: balance-rr
+      interface_properties:
+        mtu: 9000
+        vendor_specific:
+          disable_offloading: true
+    - action: add-port
+      name: bond0.102
+      bridge: br-ex
+    - action: add-br
+      name: br-floating
+      provider: ovs
+    - action: add-patch
+      bridges:
+      - br-floating
+      - br-ex
+      provider: ovs
+    - action: add-br
+      name: br-prv
+      provider: ovs
+    - action: add-patch
+      bridges:
+      - br-prv
+      - br-storage
+      provider: ovs
+  endpoints:
+    eth0:
+      IP:
+        - '10.1.0.11/24'
+    br-ex:
+      gateway: 10.1.3.1
+      IP:
+        - '10.1.3.11/24'
+    br-storage:
+      IP:
+        - '10.1.2.11/24'
+    br-mgmt:
+      IP:
+        - '10.1.1.11/24'
+    br-floating:
+      IP: none
+    br-prv:
+      IP: none
+  roles:
+    admin: eth0
+    ex: br-ex
+    management: br-mgmt
+    storage: br-storage
+    neutron/floating: br-floating
+    neutron/private: br-prv
+eof
+end
+
+
+
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  subject do
+    function_name = Puppet::Parser::Functions.function(:get_transformation_property)
+    scope.method(function_name)
+  end
+
+  context "get_transformation_property('some_property', 'transformation') usage" do
+    before(:each) do
+      scope.stubs(:lookupvar).with('l3_fqdn_hostname').returns('node1.tld')
+      L23network::Scheme.set_config(
+        scope.lookupvar('l3_fqdn_hostname'),
+        L23network.sanitize_keys_in_hash(YAML.load(network_scheme))
+      )
+    end
+
+    it 'should exist' do
+      subject == Puppet::Parser::Functions.function(:get_transformation_property)
+    end
+
+    it 'should return mtu value for "bond0" transformation' do
+      should run.with_params('mtu', 'bond0').and_return(4000)
+    end
+
+    it 'should return mtu value for "eth0" transformation' do
+      should run.with_params('mtu', 'eth0').and_return(2048)
+    end
+
+    it 'should return NIL for "eth2" transformation' do
+      should run.with_params('mtu', 'eth2').and_return(nil)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Currently MTU for Neutron private networks is always set to 1500,
which is not correct for GRE segmentation and causes performance degradation.
MTU value should also depend on MTU settings of physical interfaces.
The only way to change MTU for Neutron private network is to use an additional
dnsmasq configuration file.

Author: Sergey Kolekonov <skolekonov@mirantis.com>
Co-Authored-By: Sergey Vasilenko <svasilenko@mirantis.com>
FUEL-Change-Id: Iaa9631b58f268ec414c58d1b7c47de3573772fc5

Closes: #29