### PR TITLE
Workaround Ubuntu bug: ifup is not executed for OVS interfaces

### DIFF
--- a/lib/puppet/provider/l23_stored_config/lnx_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/lnx_ubuntu.rb
@@ -13,13 +13,27 @@ Puppet::Type.type(:l23_stored_config).provide(:lnx_ubuntu, :parent => Puppet::Pr
   self.unlink_empty_files = true
 
   def self.check_if_provider(if_data)
-    if if_data[:if_provider] == 'auto'
+    if if_data[:if_provider] =~ /lnx/
         if_data[:if_provider] = :lnx
         true
     else
         if_data[:if_provider] = nil
         false
     end
+  end
+
+  def self.iface_file_header(provider)
+    rv = []
+
+    # Add onboot interfaces
+    if provider.onboot
+      rv << "auto #{provider.name}"
+    end
+
+    # Add iface header
+    rv << "iface #{provider.name} inet #{provider.method}"
+
+    return rv, {}
   end
 
 end

--- a/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
@@ -12,14 +12,14 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
   def self.property_mappings
     rv = super
     rv.merge!({
-      :onboot => 'allow-ovs'
+      :ovs_type   => 'ovs_type',
+      :ovs_bridge => 'ovs_bridge',
     })
     return rv
   end
 
   def self.check_if_provider(if_data)
-    #((if_data[:if_provider] == 'allow-ovs')  ?  true  :  false)
-    if if_data[:if_provider] == 'allow-ovs'
+    if if_data[:if_provider].to_s =~ /ovs/
         if_data[:if_provider] = :ovs
         true
     else
@@ -27,6 +27,38 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
         false
     end
   end
+
+  def self.iface_file_header(provider)
+    header = []
+    props  = {}
+
+
+    # Add onboot interfaces
+    if provider.onboot
+      header << "auto #{provider.name}"
+    end
+
+    bridge = provider.bridge[0]
+    if provider.if_type.to_s == 'bridge'
+      header << "allow-ovs #{provider.name}"
+      props[:bridge_ports] = nil
+      props[:ovs_type] = 'OVSBridge'
+      props[:ovs_bridge] = nil
+    elsif provider.if_type.to_s == 'bond'
+      props[:ovs_type] = 'OVSBond'
+      props[:ovs_bridge] = bridge
+    else
+      header << "allow-#{bridge} #{provider.name}"
+      props[:ovs_type] = 'OVSIntPort'
+      props[:ovs_bridge] = bridge
+    end
+    # Add iface header
+    header << "iface #{provider.name} inet #{provider.method}"
+
+    return header, props
+  end
+
+
 
   def self.mangle__type(val)
     :ethernet


### PR DESCRIPTION
Interfaces are created in both modes simultaneously:
* OVS port (with additional OVS-aware directives)
* ethernet port (for executing at boot time)

FUEL-Change-Id: Id17dd4b0f875643d21fdfd62cb0fc872078e0d95

Closes: #61