### PR TITLE
Make bond names and bond-member names more corresponded

### DIFF
--- a/lib/puppet/type/l23_stored_config.rb
+++ b/lib/puppet/type/l23_stored_config.rb
@@ -194,7 +194,7 @@ Puppet::Type.newtype(:l23_stored_config) do
 
   newproperty(:bond_master) do
     desc "bond name for bonded interface"
-    newvalues(/^[\w+\-]+$/, :none, :undef, :nil, :absent)
+    newvalues(/^\w[\w+\-]*\w$/, :none, :undef, :nil, :absent)
     aliasvalue(:none,  :absent)
     aliasvalue(:undef, :absent)
     aliasvalue(:nil,   :absent)
@@ -203,7 +203,7 @@ Puppet::Type.newtype(:l23_stored_config) do
 
   newproperty(:bond_slaves, :array_matching => :all) do
     desc "slave ports for bond interface"
-    newvalues(/^[\w+\-]+$/, :false, :none, :undef, :nil, :absent)
+    newvalues(/^\w[\w+\-\.]*\w$/, :false, :none, :undef, :nil, :absent)
     #aliasvalue(:absent, :none)  # none is a valid config value
     aliasvalue(:false, :none)
     aliasvalue(:undef, :absent)

--- a/lib/puppet/type/l2_bond.rb
+++ b/lib/puppet/type/l2_bond.rb
@@ -11,7 +11,7 @@ Puppet::Type.newtype(:l2_bond) do
       desc "The bond name"
       #
       validate do |val|
-        if not val =~ /^[a-z_][\w\.\-]*[0-9a-z]$/
+        if not val =~ /^\w[\w+\-]*\w$/
           fail("Invalid bond name: '#{val}'")
         end
       end
@@ -60,7 +60,7 @@ Puppet::Type.newtype(:l2_bond) do
 
     newproperty(:slaves, :array_matching => :all) do
       desc "What bridge to use"
-      newvalues(/^[a-z][0-9a-z\-\_]*[0-9a-z]$/, :absent, :none, :undef, :nil)
+      newvalues(/^\w[\w+\-\.]*\w$/, :absent, :none, :undef, :nil)
       aliasvalue(:none,  :absent)
       aliasvalue(:undef, :absent)
       aliasvalue(:nil,   :absent)


### PR DESCRIPTION
to the Network Device Naming convention.

FUEL-Change-Id: I56b52804378938129983e6c58a6484fa276713ae
Closes: #65