### PR TITLE
Add NETWORK method for get_network_role_property function

### DIFF
--- a/lib/puppet/parser/functions/get_network_role_property.rb
+++ b/lib/puppet/parser/functions/get_network_role_property.rb
@@ -14,13 +14,14 @@ Puppet::Parser::Functions::newfunction(:get_network_role_property, :type => :rva
     This function get get network the network_role name and mode --
     and return information about network role.
 
-    ex: get_network_role_property('admin', 'interface')
+    ex: get_network_role_property('network/role', 'ipaddr')
 
     You can use following modes:
       interface -- network interface for the network_role
       ipaddr -- IP address for the network_role
       cidr -- CIDR-notated IP addr and mask for the network_role
-      netmask -- string, contains dotted nemmask
+      network -- CIDR-notated NETWORK addr and mask for the network_role
+      netmask -- string, contains dotted netmask
       ipaddr_netmask_pair -- list of ipaddr and netmask
       phys_dev -- physical device name mapped to the network with the selected network_role
 
@@ -84,6 +85,8 @@ Puppet::Parser::Functions::newfunction(:get_network_role_property, :type => :rva
   case mode
     when 'CIDR'
       rv = ipaddr_cidr
+    when 'NETWORK'
+      rv = "#{IPAddr.new(ipaddr_cidr)}/#{prepare_cidr(ipaddr_cidr)[1]}"
     when 'NETMASK'
       rv = (ipaddr_cidr.nil?  ?  nil  :  IPAddr.new('255.255.255.255').mask(prepare_cidr(ipaddr_cidr)[1]).to_s)
     when 'IPADDR'

--- a/spec/functions/get_network_role_property__spec.rb
+++ b/spec/functions/get_network_role_property__spec.rb
@@ -62,6 +62,10 @@ describe Puppet::Parser::Functions.function(:get_network_role_property) do
       should run.with_params('management', 'cidr').and_return('10.20.1.11/25')
     end
 
+    it 'should return cidr-notated network address for "management" network role' do
+      should run.with_params('management', 'network').and_return('10.20.1.0/25')
+    end
+
     it 'should return netmask for "management" network role' do
       should run.with_params('management', 'netmask').and_return('255.255.255.128')
     end


### PR DESCRIPTION
This method should return network in CIDR notation
for given network role

FUEL-Change-Id: I080eb561dd795957ee59bca3fe55adea99a13c10
Closes: #96