### PR TITLE
Refactor OVS-patchcord provider

### DIFF
--- a/lib/puppet/parser/functions/generate_network_config.rb
+++ b/lib/puppet/parser/functions/generate_network_config.rb
@@ -81,6 +81,7 @@ module L23network
       when "add-patch" then {
         :name            => "unnamed", # calculated later
         :bridges         => [],
+        :vlan_ids        => [0, 0],
         :mtu             => nil,
         :vendor_specific => nil,
         :provider        => def_provider

--- a/lib/puppet/parser/functions/get_pair_of_jack_names.rb
+++ b/lib/puppet/parser/functions/get_pair_of_jack_names.rb
@@ -2,14 +2,12 @@ require 'puppetx/l23_utils'
 #
 module Puppet::Parser::Functions
   newfunction(:get_pair_of_jack_names, :type => :rvalue) do |arguments|
+    # arguments[0] -- is a bridges list of two elements
     if !arguments[0].is_a? Array or arguments.size != 1 or arguments[0].size != 2
       raise(Puppet::ParseError, "get_pair_of_jack_names(): Wrong arguments given. " +
         "Should be array of two bridge names.")
     end
-
-    bridges = arguments[0]
-    # name shouldn't depend from bridge order
-    L23network.get_pair_of_jack_names(bridges)
+   L23network.get_pair_of_jack_names(arguments[0])
   end
 end
 # vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l2_patch/ovs.rb
+++ b/lib/puppet/provider/l2_patch/ovs.rb
@@ -43,25 +43,28 @@ Puppet::Type.type(:l2_patch).provide(:ovs, :parent => Puppet::Provider::Ovs_base
         # process 'cross' patch between OVS and LNX bridge
         peer = lnx_port_br_mapping[jack[:name]]
         next if peer.nil?
-        _bridges = [jack[:bridge], peer[:bridge]]  # no sort here!!! architecture limitation -- ovs brodge always first!
-        _tails   = [jack[:name], jack[:name]]
-        mtu      = File.open("/sys/class/net/#{jack[:name]}/mtu").read.chomp.to_i
+        _bridges  = [jack[:bridge], peer[:bridge]]  # no sort here!!! architecture limitation -- ovs brodge always first!
+        _tails    = [jack[:name], jack[:name]]
+        _vlan_ids = [(jack[:vlan_id].to_i or 0), 0]
+        mtu       = File.open("/sys/class/net/#{jack[:name]}/mtu").read.chomp.to_i
       else
         # process patch between two OVS bridges
         next if jack[:peer].nil?
         found_peer = jacks.select{|j| j[:name]==jack[:peer]}
         next if found_peer.empty?
         peer = found_peer[0]
-        _bridges = [jack[:bridge], peer[:bridge]].sort
-        _tails   = ([jack[:bridge], peer[:bridge]] == _bridges  ?  [jack[:name], peer[:name]]  :  [peer[:name], jack[:name]])
+        _bridges  = [jack[:bridge], peer[:bridge]].sort
+        _tails    = ([jack[:bridge], peer[:bridge]] == _bridges  ?  [jack[:name], peer[:name]]  :  [peer[:name], jack[:name]])
+        _vlan_ids = [(jack[:vlan_id].to_i or 0), (peer[:vlan_id].to_i or 0)]
       end
       props = {
         :ensure   => :present,
         :name     => L23network.get_patch_name([jack[:bridge],peer[:bridge]]),
         :bridges  => _bridges,
         :jacks    => _tails,
-        :mtu      => mtu,
+        :mtu      => mtu.to_s,
         :cross    => jack[:cross],
+        :vlan_ids => _vlan_ids.map{|x| x.to_s},
         :provider => 'ovs'
       }
       debug("PREFETCH properties for '#{props[:name]}': #{props}")
@@ -80,11 +83,13 @@ Puppet::Type.type(:l2_patch).provide(:ovs, :parent => Puppet::Provider::Ovs_base
     bridges = self.class.get_bridges_order_for_patch(@resource[:bridges])
     @property_flush[:bridges] = bridges
     #
-    debug("Bridges: '#{bridges.join(', ')}.")
+    debug("Bridges: '#{bridges.join(', ')}'.")
     if File.directory?("/sys/class/net/#{bridges[1]}/bridge")
       # creating 'cross' OVS-to-lnx patchcord
+      @resource[:cross] = true
       lnx_port_br_mapping = self.class.get_lnx_port_bridges_pairs()
-      jack = L23network.get_lnx_jack_name(bridges[0])
+      jack = L23network.get_jack_name(bridges[0],0)
+      @resource[:jacks] = [jack, jack]
       vsctl('--may-exist', 'add-port', bridges[0], jack, '--', 'set', 'Interface', jack, 'type=internal')
       if lnx_port_br_mapping.has_key? jack and lnx_port_br_mapping[jack][:bridge] != bridges[1]
         # eject lnx-side jack from bridge, if jack aldeady a member
@@ -102,15 +107,17 @@ Puppet::Type.type(:l2_patch).provide(:ovs, :parent => Puppet::Provider::Ovs_base
           end
         end
       end
+      iproute('link', 'set', 'up', 'dev', jack)
     else
       # creating OVS-to-OVS patchcord
       jacks = []
-      jacks << L23network.get_ovs_jack_name(bridges[1])
-      jacks << L23network.get_ovs_jack_name(bridges[0])
+      jacks << L23network.get_jack_name(bridges,0)
+      jacks << L23network.get_jack_name(bridges,1)
       #todo(sv): make type and peer change in flush
       cmds = []
       cmds << ['--may-exist', 'add-port', bridges[0], jacks[0], '--', 'set', 'Interface', jacks[0], 'type=patch', "option:peer=#{jacks[1]}"]
       cmds << ['--may-exist', 'add-port', bridges[1], jacks[1], '--', 'set', 'Interface', jacks[1], 'type=patch', "option:peer=#{jacks[0]}"]
+debug(cmds)
       cmds.each do |cmd|
         begin
           vsctl(cmd)
@@ -119,12 +126,13 @@ Puppet::Type.type(:l2_patch).provide(:ovs, :parent => Puppet::Provider::Ovs_base
         end
       end
     end
+    @property_hash = resource.to_hash
   end
 
   def destroy
     if File.directory?("/sys/class/net/#{@resource[:bridges][1]}/bridge")
       # removing 'cross' OVS-to-lnx patchcord
-      jack = L23network.get_lnx_jack_name(@resource[:bridges][0])
+      jack = L23network.get_jack_name(@resource[:bridges][0], 0)
       if File.symlink?("/sys/class/net/#{@resource[:bridges][1]}/brif/#{jack}")
         brctl('delif', @resource[:bridges][1], jack)
       end
@@ -133,8 +141,8 @@ Puppet::Type.type(:l2_patch).provide(:ovs, :parent => Puppet::Provider::Ovs_base
       # removing OVS-to-OVS patchcord
       bridges = @resource[:bridges].sort
       jacks = []
-      jacks << L23network.get_ovs_jack_name(bridges[1])
-      jacks << L23network.get_ovs_jack_name(bridges[0])
+      jacks << L23network.get_jack_name(bridges,1)
+      jacks << L23network.get_jack_name(bridges,0)
       cmds = []
       cmds << ['del-port', bridges[0], jacks[0]]
       cmds << ['del-port', bridges[1], jacks[1]]
@@ -151,10 +159,28 @@ Puppet::Type.type(:l2_patch).provide(:ovs, :parent => Puppet::Provider::Ovs_base
   def flush
     if !@property_flush.empty?
       debug("FLUSH properties: #{@property_flush}")
+#      debug("For resource #{@resource.to_yaml}")
       if !['', 'absent'].include? @property_flush[:mtu].to_s
         # 'absent' is a synonym 'do-not-touch' for MTU
-        @resource[:jacks].uniq.each do |iface|
+        @property_hash[:jacks].uniq.each do |iface|
           self.class.set_mtu(iface, @property_flush[:mtu])
+        end
+      end
+      if @property_flush.has_key? :vlan_ids
+        debug("Operate cross-bridge patchcord.") if @property_hash[:cross]
+        real_jack_count = @property_hash[:jacks].uniq.length
+        (0..real_jack_count-1).each do |i|
+          tag = @property_flush[:vlan_ids][i].to_i
+          if tag != 0
+            # set 802.1q tag to port
+            vsctl('set', 'Port', @property_hash[:jacks][i], "tag=#{tag}")
+          else
+            # remove 802.1q tag from port
+            vsctl('set', 'Port', @property_hash[:jacks][i], "tag=[]")
+          end
+        end
+        if real_jack_count == 1 and @property_hash[:vlan_ids][1] != @property_flush[:vlan_ids][1]
+          warn("You try to change vlan_id for LNX jack of cross-patch-cord, but it's impossible!")
         end
       end
       @property_hash = resource.to_hash
@@ -168,6 +194,13 @@ Puppet::Type.type(:l2_patch).provide(:ovs, :parent => Puppet::Provider::Ovs_base
   end
   def bridges=(val)
     @property_flush[:bridges] = self.class.get_bridges_order_for_patch(val)
+  end
+
+  def vlan_ids
+    @property_hash[:vlan_ids]
+  end
+  def vlan_ids=(val)
+    @property_flush[:vlan_ids] = val
   end
 
   def jacks

--- a/lib/puppet/provider/l2_port/ovs.rb
+++ b/lib/puppet/provider/l2_port/ovs.rb
@@ -82,7 +82,7 @@ Puppet::Type.type(:l2_port).provide(:ovs, :parent => Puppet::Provider::Ovs_base)
           vsctl('set', 'Port', @resource[:interface], "tag=#{@property_flush[:vlan_id].to_i}")
         else
           # remove 802.1q tag
-          vsctl('set', 'Port', @resource[:interface], "tag='[]'")
+          vsctl('set', 'Port', @resource[:interface], "tag=[]")
         end
       end
       @property_hash = resource.to_hash

--- a/lib/puppet/type/l2_patch.rb
+++ b/lib/puppet/type/l2_patch.rb
@@ -24,7 +24,7 @@ Puppet::Type.newtype(:l2_patch) do
     end
 
     newproperty(:jacks, :array_matching => :all) do
-      desc "Patchcord jacks. Read-only. for debug purpose."
+      desc "Patchcord jacks. Read-only. for debug and internal usage only."
 
       def should_to_s(value)
         "#{value.join(':')}"
@@ -35,12 +35,34 @@ Puppet::Type.newtype(:l2_patch) do
       end
 
       def insync?(value)
-        should_to_s(value) == should_to_s(should)
+        should_to_s(value.sort) == should_to_s(should.sort)
       end
     end
 
     newproperty(:cross) do
       desc "Cross-system patch. Read-only. for debug purpose."
+    end
+
+    #newparam(:vlan_ids) do #, :array_matching => :all) do
+    newproperty(:vlan_ids, :array_matching => :all) do
+      desc "Array of 802.1q vlan IDs for patchcords ends. Actual only for OVS implementations"
+      defaultto [0,0]
+
+      validate do |val|
+        fail("Wrong 802.1q tag. Tag must be an integer in 2..4094 interval") if (val.to_i < 0 or val.to_i > 4094)
+      end
+
+      def should_to_s(value)
+        "#{value.join(':')}"
+      end
+      def is_to_s(value)
+        "#{value.join(':')}"
+      end
+
+      def insync?(value)
+        value == should
+      end
+
     end
 
     newproperty(:mtu) do

--- a/lib/puppetx/l23_utils.rb
+++ b/lib/puppetx/l23_utils.rb
@@ -1,3 +1,5 @@
+require 'zlib'
+
 module L23network
   def self.reccursive_sanitize_hash(data)
     if data.is_a? Hash
@@ -26,38 +28,29 @@ module L23network
     "patch__#{bridges.map{|s| s.to_s}.sort.join('--')}"
   end
 
-  def self.ovs_jack_name_len
-    13
-  end
-
-  def self.get_ovs_jack_name(bridge)
-    # bridges should be an array of two string
-    tail = bridge[0..ovs_jack_name_len-1]
-    "p_#{tail}"
-  end
-
   def self.lnx_jack_name_len
     11
   end
 
-  def self.get_lnx_jack_name(bridge, num=0)
-    # bridges should be an array of two string
-    tail = bridge[0..lnx_jack_name_len-1]
-    "p_#{tail}-#{num}"
+  def self.get_base_name_for_jacks(bridges)
+    sprintf("p_%08x",Zlib::crc32(get_patch_name(bridges)).to_i)
+  end
+
+  def self.get_jack_name(bridges, num=0)
+    # ideally, bridges should be an array of two string
+    if bridges.is_a? String
+      jj = [bridges,bridges]
+    elsif bridges.is_a? Array and bridges.length==1
+      jj = [bridges[0],bridges[0]]
+    else
+      jj = bridges[0..1]
+    end
+    base_name=get_base_name_for_jacks(jj)
+    return "#{base_name}-#{num}"
   end
 
   def self.get_pair_of_jack_names(bridges)
-    if bridges.is_a? String
-      j1 = get_lnx_jack_name(bridges,0)
-      j2 = get_lnx_jack_name(bridges,1)
-    elsif bridges.is_a? Array and bridges.length==1
-      j1 = get_lnx_jack_name(bridges[0],0)
-      j2 = get_lnx_jack_name(bridges[0],1)
-    else
-      j1 = get_lnx_jack_name(bridges[0],0)
-      j2 = get_lnx_jack_name(bridges[1],1)
-    end
-    return [j1, j2]
+    [get_jack_name(bridges,0), get_jack_name(bridges,1)]
   end
 
 # def self.reccursive_merge_hash(a,b)

--- a/manifests/l2/patch.pp
+++ b/manifests/l2/patch.pp
@@ -6,14 +6,19 @@
 # [*bridges*]
 #   Bridges that will be connected.
 #
-# [*peers*]
-#   Patch port names for both bridges. must be array of two strings.
+# [*mtu*]
+#   Specify MTU value for patchcord.
+#
+# [*vlan_ids*]
+#   Specify 802.1q tag for each end of patchcord. Must be array of 2 integers.
+#   Default [0,0] -- untagged
 #
 define l23network::l2::patch (
   $bridges,
   $use_ovs         = $::l23network::use_ovs,
   $ensure          = present,
   $mtu             = undef,
+  $vlan_ids        = undef,
   $vendor_specific = undef,
   $provider        = undef,
 ) {
@@ -59,6 +64,7 @@ define l23network::l2::patch (
       bridges         => $bridges,
       use_ovs         => $use_ovs,
       jacks           => $patch_jacks_names,
+      vlan_ids        => $vlan_ids,
       mtu             => $mtu,
       vendor_specific => $vendor_specific,
       provider        => $provider

--- a/spec/defines/l2_patch__spec.rb
+++ b/spec/defines/l2_patch__spec.rb
@@ -1,5 +1,10 @@
 require 'spec_helper'
 
+# NOTE: In this test 'p_39a440c1-N' is a patchcord name for
+# ['br1', 'br2'] bridges. Central part of name calculated as
+# CRC32 of patchcord resource name and depends ONLY of bridge
+# names, that connected by patchcord.
+
 describe 'l23network::l2::patch', :type => :define do
   let(:title) { 'Spec for l23network::l2::port' }
   let(:facts) { {
@@ -26,14 +31,12 @@ describe 'l23network::l2::patch', :type => :define do
     end
 
     it do
-      should contain_l23_stored_config('p_br1-0').only_with({
-        'use_ovs' => nil,
-        'method'  => nil,
+      should contain_l23_stored_config('p_39a440c1-0').with({
         'ipaddr'  => nil,
         'gateway' => nil,
         'onboot'  => true,
         'bridge'  => ['br1', 'br2'],
-        'jacks'   => ['p_br1-0', 'p_br2-1']
+        'jacks'   => ['p_39a440c1-0', 'p_39a440c1-1']
       })
     end
 
@@ -41,7 +44,67 @@ describe 'l23network::l2::patch', :type => :define do
       should contain_l2_patch('patch__br1--br2').with({
         'ensure'  => 'present',
         'bridges' => ['br1', 'br2'],
-      }).that_requires('L23_stored_config[p_br1-0]')
+      }).that_requires('L23_stored_config[p_39a440c1-0]')
+    end
+  end
+
+  context 'Just a patch between two bridges in reverse order' do
+    let(:params) do
+      {
+        :bridges => ['br2', 'br1'],
+      }
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_l23_stored_config('p_39a440c1-0').with({
+        'ipaddr'  => nil,
+        'gateway' => nil,
+        'onboot'  => true,
+        'bridge'  => ['br2', 'br1'],
+        'jacks'   => ['p_39a440c1-0', 'p_39a440c1-1']
+      })
+    end
+
+    it do
+      should contain_l2_patch('patch__br1--br2').with({
+        'ensure'  => 'present',
+        'bridges' => ['br2', 'br1'],
+      }).that_requires('L23_stored_config[p_39a440c1-0]')
+    end
+  end
+
+  context 'Just a patch between two OVS bridges' do
+    let(:params) do
+      {
+        :bridges  => ['br1', 'br2'],
+        :provider => 'ovs'
+      }
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_l23_stored_config('p_39a440c1-0').with({
+        'ipaddr'  => nil,
+        'gateway' => nil,
+        'onboot'  => true,
+        'bridge'  => ['br1', 'br2'],
+        'jacks'   => ['p_39a440c1-0', 'p_39a440c1-1']
+      })
+    end
+
+    it do
+      should contain_l2_patch('patch__br1--br2').with({
+        'ensure'  => 'present',
+        'bridges' => ['br1', 'br2'],
+        'jacks'   => ['p_39a440c1-0', 'p_39a440c1-1']
+      }).that_requires('L23_stored_config[p_39a440c1-0]')
     end
   end
 
@@ -55,16 +118,16 @@ describe 'l23network::l2::patch', :type => :define do
 
     it do
       should compile
-      should contain_l23_stored_config('p_br1-0').with({
+      should contain_l23_stored_config('p_39a440c1-0').with({
         'bridge'  => ['br1', 'br2'],
-        'jacks'   => ['p_br1-0', 'p_br2-1'],
+        'jacks'   => ['p_39a440c1-0', 'p_39a440c1-1'],
         'mtu'     => 9000,
       })
       should contain_l2_patch('patch__br1--br2').with({
         'ensure'  => 'present',
         'mtu'     => 9000,
         'bridges' => ['br1', 'br2'],
-      }).that_requires('L23_stored_config[p_br1-0]')
+      }).that_requires('L23_stored_config[p_39a440c1-0]')
     end
   end
 
@@ -84,9 +147,9 @@ describe 'l23network::l2::patch', :type => :define do
 
     it do
       should compile
-      should contain_l23_stored_config('p_br1-0').with({
+      should contain_l23_stored_config('p_39a440c1-0').with({
         'bridge'          => ['br1', 'br2'],
-        'jacks'           => ['p_br1-0', 'p_br2-1'],
+        'jacks'           => ['p_39a440c1-0', 'p_39a440c1-1'],
         'vendor_specific' => {
             'aaa' => '111',
             'bbb' => {
@@ -105,7 +168,36 @@ describe 'l23network::l2::patch', :type => :define do
                 'bbb2' => ['b1','b2','b3']
             },
         },
-      }).that_requires('L23_stored_config[p_br1-0]')
+      }).that_requires('L23_stored_config[p_39a440c1-0]')
+    end
+  end
+
+  context 'Tagged patchcord between OVS bridges' do
+    let(:params) do
+      {
+        :bridges  => ['br1', 'br2'],
+        :vlan_ids => ['101', '202'],
+        :provider => 'ovs'
+      }
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_l23_stored_config('p_39a440c1-0').with({
+        'bridge'  => ['br1', 'br2'],
+        'jacks'   => ['p_39a440c1-0', 'p_39a440c1-1']
+      })
+    end
+
+    it do
+      should contain_l2_patch('patch__br1--br2').with({
+        'ensure'   => 'present',
+        'vlan_ids' => ['101', '202'],
+        'bridges'  => ['br1', 'br2'],
+      }).that_requires('L23_stored_config[p_39a440c1-0]')
     end
   end
 

--- a/spec/functions/get_pair_of_jack_names__spec.rb
+++ b/spec/functions/get_pair_of_jack_names__spec.rb
@@ -1,5 +1,10 @@
 require 'spec_helper'
 
+# NOTE: In this test 'p_39a440c1-N' is a patchcord name for
+# ['br1', 'br2'] bridges. Central part of name calculated as
+# CRC32 of patchcord resource name and depends ONLY of bridge
+# names, that connected by patchcord.
+
 describe 'get_pair_of_jack_names' do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
@@ -23,12 +28,16 @@ describe 'get_pair_of_jack_names' do
       should run.with_params([1,2],[3,4]).and_raise_error(Puppet::ParseError)
     end
 
-    it 'should return numbered interface names' do
-      should run.with_params(['br-mgmt', 'br-ex']).and_return(["p_br-mgmt-0", "p_br-ex-1"])
+    it 'should return numbered interface names for pair of bridges' do
+      should run.with_params(['br1', 'br2']).and_return(["p_39a440c1-0", "p_39a440c1-1"])
     end
 
-    it 'should cut interface names for long interfaces' do
-      should run.with_params(['br-mmmmmmmmmmmmmmmmmmmmmmmmgmt', 'br-ex']).and_return(["p_br-mmmmmmmm-0", "p_br-ex-1"])
+    it 'should return numbered interface names for pair of bridges in reverse order' do
+      should run.with_params(['br2', 'br1']).and_return(["p_39a440c1-0", "p_39a440c1-1"])
+    end
+
+    it 'should return numbered interface names for pair of bridges with long name' do
+      should run.with_params(['br-mmmmmmmmmmmmmmmmmmmmmmmmgmt', 'br-ex']).and_return(["p_0c7224e9-0", "p_0c7224e9-1"])
     end
 
   end

--- a/spec/unit/puppet/provider/l2_patch/ovs_patch__spec.rb
+++ b/spec/unit/puppet/provider/l2_patch/ovs_patch__spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l2_patch).provider(:ovs) do
+  # NOTE! for bridges ['br1', 'br2'] jack names will be ['p_39a440c1-0', 'p_39a440c1-1']
+
+
+  let(:resource_br1) {
+    Puppet::Type.type(:l2_bridge).new(
+      :provider => 'ovs',
+      :name     => 'br1',
+      :bridge   => 'br1',
+    )
+  }
+  let(:provider_br1) { resource_br1.provider }
+  #let(:instance_br1_ovs) { provider_br1.class.instances }
+
+  let(:resource_patch) {
+    Puppet::Type.type(:l2_patch).new(
+      :provider => 'ovs',
+      :name     => 'patch__br1--br2',
+      :bridges  => ['br1', 'br2'],
+      :jacks    => ['p_39a440c1-0', 'p_39a440c1-1'],
+      :vlan_ids => ['0', '0'],
+    )
+  }
+  let(:provider_patch) { resource_patch.provider }
+  #let(:instance_patch_ovs) { provider_patch.class.instances }
+
+  describe "ovs-to-ovs patchcord" do
+
+    let(:resource_br2) {
+      Puppet::Type.type(:l2_bridge).new(
+        :provider => 'ovs',
+        :name     => 'br2',
+        :bridge   => 'br2',
+      )
+    }
+    let(:provider_br2) { resource_br2.provider }
+    #let(:instance_br2_ovs) { provider_br2.class.instances }
+
+
+    before(:each) do
+      if ENV['SPEC_PUPPET_DEBUG']
+        Puppet::Util::Log.level = :debug
+        Puppet::Util::Log.newdestination(:console)
+      end
+      provider_br1.class.stubs(:iproute)
+      provider_br2.class.stubs(:iproute)
+      provider_br1.class.stubs(:vsctl).with('add-br', 'br1').returns(true)
+      provider_br2.class.stubs(:vsctl).with('add-br', 'br2').returns(true)
+      provider_patch.class.stubs(:vsctl).with([
+        '--may-exist', 'add-port', 'br1', 'p_39a440c1-0', '--', 'set', 'Interface', 'p_39a440c1-0', 'type=patch', 'option:peer=p_39a440c1-1'
+      ]).returns(true)
+      provider_patch.class.stubs(:vsctl).with([
+        '--may-exist', 'add-port', 'br2', 'p_39a440c1-1', '--', 'set', 'Interface', 'p_39a440c1-1', 'type=patch', 'option:peer=p_39a440c1-0'
+      ]).returns(true)
+    end
+
+    it "Just create two bridges and connect it by patchcord" do
+      provider_br1.create
+      provider_br2.create
+      provider_patch.create
+    end
+
+  end
+
+  describe "ovs-to-lnx patchcord" do
+
+    let(:resource_br2) {
+      Puppet::Type.type(:l2_bridge).new(
+        :provider => 'lnx',
+        :name     => 'br2',
+        :bridge   => 'br2',
+      )
+    }
+    let(:provider_br2) { resource_br2.provider }
+    #let(:instance_br2_ovs) { provider_br2.class.instances }
+
+
+    before(:each) do
+      if ENV['SPEC_PUPPET_DEBUG']
+        Puppet::Util::Log.level = :debug
+        Puppet::Util::Log.newdestination(:console)
+      end
+      provider_br1.class.stubs(:iproute)
+      provider_br1.class.stubs(:vsctl).with('add-br', 'br1').returns(true)
+      provider_br2.class.stubs(:iproute).with().returns(true)
+      provider_br2.class.stubs(:iproute).with('link', 'set', 'up', 'dev', 'br2').returns(true)
+      provider_br2.class.stubs(:brctl).with('addbr', 'br2').returns(true)
+      provider_patch.class.stubs(:brctl).with('addif', 'br2', 'p_a0ad117b-0').returns(true)
+      provider_patch.class.stubs(:vsctl).with(
+        '--may-exist', 'add-port', 'br1', 'p_a0ad117b-0', '--', 'set', 'Interface', 'p_a0ad117b-0', 'type=internal'
+      ).returns(true)
+      File.stubs(:directory?).with('/sys/class/net/br2/bridge').returns(true)
+      provider_patch.class.stubs(:get_lnx_port_bridges_pairs).with().returns({})
+      provider_patch.class.stubs(:get_bridges_order_for_patch).with(['br1','br2']).returns(['br1','br2'])
+      provider_patch.class.stubs(:iproute).with('link', 'set', 'up', 'dev', 'p_a0ad117b-0').returns(true)
+    end
+
+    it "Just create two bridges and connect it by patchcord" do
+      provider_br1.create
+      provider_br2.create
+      provider_patch.create
+    end
+
+  end
+
+end


### PR DESCRIPTION
* Add 'vlan_ids' property to the l2_patch resource
* fix up-state for ovs-to-lnx petchcord
* adopt specs

FUEL-Change-Id: Ibc766ca716006cecfec11774ea97c016bb2f60f0
Closes: #70