### PR TITLE
Fix regression in the lnx bond config file generation

### DIFF
--- a/lib/puppet/provider/l23_stored_config_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config_ubuntu.rb
@@ -365,7 +365,7 @@ class Puppet::Provider::L23_stored_config_ubuntu < Puppet::Provider::L23_stored_
     provider = providers[0]
     content, props = iface_file_header(provider)
 
-    property_mappings.keys.select{|v| !(properties_fake.include?(v) or v.empty?)}.each do |type_name|
+    property_mappings.reject{|k,v| (properties_fake.include?(k) or v.empty?)}.keys.each do |type_name|
       next if props.has_key? type_name
       val = provider.send(type_name)
       if val and val.to_s != 'absent'

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-bond0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-bond0
@@ -1,0 +1,8 @@
+auto bond0
+iface bond0 inet manual
+  mtu 9000
+  bond-mode 802.3ad
+  bond-miimon 50
+  bond-lacp-rate fast
+  bond-slaves eth2 eth3
+  bond-xmit-hash-policy encap3+4

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge
@@ -1,3 +1,4 @@
 allow-ovs br9
 iface br9 inet manual
   ovs_type OVSBridge
+  mtu 9000

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__bond__spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 require 'yaml'
 
-describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
+describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
 
   let(:input_data) do
     {
-      :bond_lacp => {
-        :name           => 'bond_lacp',
+      :bond0 => {
+        :name           => 'bond0',
         :ensure         => 'present',
         :if_type        => 'bond',
-        :bridge         => 'br0',
         :mtu            => '9000',
         :onboot         => true,
         :method         => 'manual',
-        :bond_mode      => 'balance-tcp',
+        :bond_mode      => '802.3ad',
+        :bond_xmit_hash_policy => 'encap3+4',
         :bond_slaves    => ['eth2', 'eth3'],
         :bond_miimon    => '50',
         :bond_lacp_rate => 'fast',
-        :bond_lacp      => 'active',
-        :provider       => "ovs_ubuntu",
+        :bond_lacp      => 'passive',  # used only for OVS bonds. Should do nothing for lnx.
+        :provider       => "lnx_ubuntu",
       },
     }
   end
@@ -56,7 +56,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
   end
 
   def fixture_path
-    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'ovs_ubuntu__spec')
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'lnx_ubuntu__spec')
   end
 
   def fixture_file(file)
@@ -77,35 +77,32 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
   context "OVS bond with two interfaces" do
 
     context 'format file' do
-      subject { providers[:bond_lacp] }
+      subject { providers[:bond0] }
       let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
-      it { expect(cfg_file).not_to match(/auto\s+bond_lacp/) }
-      it { expect(cfg_file).to match(/iface\s+bond_lacp\s+inet\s+manual/) }
+      it { expect(cfg_file).to match(/auto\s+bond0/) }
+      it { expect(cfg_file).to match(/iface\s+bond0\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/mtu\s+9000/) }
-      it { expect(cfg_file).to match(/ovs_bonds\s+eth2\s+eth3/) }
-      it { expect(cfg_file).to match(/ovs_type\s+OVSBond/) }
-      it { expect(cfg_file).to match(/ovs_bridge\s+br0/) }
-      it { expect(cfg_file).to match(/ovs_options.+bond_mode=balance-tcp/) }
-      it { expect(cfg_file).to match(/ovs_options.+other_config:lacp-time=fast/) }
-      it { expect(cfg_file).to match(/ovs_options.+other_config:bond-miimon-interval=50/) }
-      it { expect(cfg_file).to match(/ovs_options.+lacp=active/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }  #  no more lines in the interface file
-
+      it { expect(cfg_file).to match(/bond-slaves\s+eth2\s+eth3/) }
+      it { expect(cfg_file).to match(/bond-lacp-rate\s+fast/) }
+      it { expect(cfg_file).to match(/bond-mode\s+802\.3ad/) }
+      it { expect(cfg_file).to match(/bond-miimon\s+50/) }
+      it { expect(cfg_file).to match(/bond-xmit-hash-policy\s+encap3\+4/) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(8) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do
-      let(:res) { subject.class.parse_file('bond_lacp', fixture_data('ifcfg-bond_lacp'))[0] }
+      let(:res) { subject.class.parse_file('bond_0', fixture_data('ifcfg-bond0'))[0] }
 
       it { expect(res[:method]).to eq :manual }
       it { expect(res[:mtu]).to eq '9000' }
-      it { expect(res[:bridge]).to eq 'br0' }
       it { expect(res[:if_type].to_s).to eq 'bond' }
-      it { expect(res[:if_provider].to_s).to eq 'ovs' }
-      it { expect(res[:bond_mode]).to eq 'balance-tcp' }
+      it { expect(res[:if_provider].to_s).to eq 'lnx' }
+      it { expect(res[:bond_mode]).to eq '802.3ad' }
       it { expect(res[:bond_miimon]).to eq '50' }
       it { expect(res[:bond_lacp_rate]).to eq 'fast' }
-      it { expect(res[:bond_lacp]).to eq 'active' }
+      it { expect(res[:bond_lacp]).to eq nil }
       it { expect(res[:bond_slaves]).to eq ['eth2', 'eth3'] }
+      it { expect(res[:bond_xmit_hash_policy]).to eq 'encap3+4' }
     end
 
   end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
@@ -77,12 +77,15 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/allow-ovs\s+br9/) }
       it { expect(cfg_file).to match(/iface\s+br9\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSBridge/) }
+      it { expect(cfg_file).to match(/mtu\s+9000/) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do
       let(:res) { subject.class.parse_file('br9', fixture_data('ifcfg-bridge'))[0] }
       it { expect(res[:method]).to eq :manual }
       it { expect(res[:name]).to eq 'br9' }
+      it { expect(res[:mtu]).to eq '9000' }
       it { expect(res[:if_type].to_s).to eq 'bridge' }
       it { expect(res[:if_provider].to_s).to eq 'ovs' }
     end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__port__spec.rb
@@ -79,6 +79,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/mtu\s+6000/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSIntPort/) }
       it { expect(cfg_file).to match(/ovs_bridge\s+br9/) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do


### PR DESCRIPTION
+ add control of amount non-empty lines in the geenerated
interface file. This change helps to prevent happening
unwanted lines in a generated config files.

FUEL-Change-Id: If9afa767ac62287003d8c0f0015cd70b63a929f4
Closes: #110