### PR TITLE
Prevent bond and bridge names looks like name of

### DIFF
--- a/lib/puppet/type/l2_bond.rb
+++ b/lib/puppet/type/l2_bond.rb
@@ -11,8 +11,23 @@ Puppet::Type.newtype(:l2_bond) do
       desc "The bond name"
       #
       validate do |val|
-        if not val =~ /^\w[\w+\-]*\w$/
-          fail("Invalid bond name: '#{val}'")
+        err = "Wrong bond name:"
+        if not val =~ /^[a-z][0-9a-z\-]*[0-9a-z]$/
+          fail("#{err} '#{val}'")
+        end
+        if val.length > 15
+          fail("#{err} Name too long: '#{val}'. Allowed not more 15 chars.")
+        end
+        if ! [Regexp.new(/^br\-?.*/),
+              Regexp.new(/^wlan.*/),
+              Regexp.new(/^lo\d*/),
+              Regexp.new(/^eth.*/),
+              Regexp.new(/^en[ospx]\h+/),
+              Regexp.new(/^em\d*/),
+              Regexp.new(/^p\d+p\d+/),
+              Regexp.new(/^ib[\h\.]+/),
+        ].select{|x| x.match(val)}.empty?
+          fail("#{err} '#{val}'")
         end
       end
     end

--- a/lib/puppet/type/l2_bridge.rb
+++ b/lib/puppet/type/l2_bridge.rb
@@ -12,8 +12,23 @@ Puppet::Type.newtype(:l2_bridge) do
       desc "The bridge to configure"
       #
       validate do |val|
-        if not val =~ /^[a-z][0-9a-z\.\-\_]*[0-9a-z]$/
-          fail("Wrong bridge name: '#{val}'")
+        err = "Wrong bridge name:"
+        if not val =~ /^[a-z][0-9a-z\-]*[0-9a-z]$/
+          fail("#{err} '#{val}'")
+        end
+        if val.length > 15
+          fail("#{err} Name too long: '#{val}'. Allowed not more 15 chars.")
+        end
+        if ! [Regexp.new(/^bond.*/),
+              Regexp.new(/^wlan.*/),
+              Regexp.new(/^lo\d*/),
+              Regexp.new(/^eth.*/),
+              Regexp.new(/^en[ospx]\h+/),
+              Regexp.new(/^em\d*/),
+              Regexp.new(/^p\d+p\d+/),
+              Regexp.new(/^ib[\h\.]+/),
+        ].select{|x| x.match(val)}.empty?
+          fail("#{err} '#{val}'")
         end
       end
     end

--- a/spec/types/l2_bond__spec.rb
+++ b/spec/types/l2_bond__spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l2_bond) do
+  context 'Create bond with wrong name' do
+    before(:each) do
+      if ENV['SPEC_PUPPET_DEBUG']
+        Puppet::Util::Log.level = :debug
+        Puppet::Util::Log.newdestination(:console)
+      end
+    end
+
+    [ 'br2', 'br-2',                                   # bond is not an bridge
+      'wlan34', 'wlan-public',                         # names for hw wifi cards
+      'lo', 'lo2', 'lo-true',                          # loopback not allowed
+      'eth', 'eth1',                                   # old style interface naming. bridge != HW interface
+      'eno3ac5', 'ensc65d', 'enp334', 'enx00adbc3421', # new style interface naming. bridge != HW interface
+      'em', 'em4',                                     # new style interface naming. bridge != HW interface
+      'p0p1',                                          # new style interface naming. bridge != HW interface
+      'ib', 'ib23', 'ib4.1001', 'ibA.ABCD.E',          # infiniband-based names
+      'qwe4567890123456', '5fgtr', 'br32-', 'br_32',   # wrong length, start from digit, wrong end or char inside name
+    ].each do |iname|
+
+      it "should be failed for name #{iname}" do
+        expect { described_class.new({
+          :name   => "#{iname}",
+        })}.to raise_error(Puppet::ResourceError, /Wrong\s+bond\s+name/)
+      end
+
+    end
+  end
+end
+# vim: set ts=2 sw=2 et

--- a/spec/types/l2_bridge__spec.rb
+++ b/spec/types/l2_bridge__spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l2_bridge) do
+  context 'Create bridge with wrong name' do
+    before(:each) do
+      if ENV['SPEC_PUPPET_DEBUG']
+        Puppet::Util::Log.level = :debug
+        Puppet::Util::Log.newdestination(:console)
+      end
+    end
+
+    [ 'bond4', 'bond-ovs',                             # bridge is not a bond
+      'wlan34', 'wlan-public',                         # names for hw wifi cards
+      'lo', 'lo2', 'lo-true',                          # loopback not allowed
+      'eth', 'eth1',                                   # old style interface naming. bridge != HW interface
+      'eno3ac5', 'ensc65d', 'enp334', 'enx00adbc3421', # new style interface naming. bridge != HW interface
+      'em', 'em4',                                     # new style interface naming. bridge != HW interface
+      'p0p1',                                          # new style interface naming. bridge != HW interface
+      'ib', 'ib23', 'ib4.1001', 'ibX.ABCD.E',          # infiniband-based names
+      'qwe4567890123456', '5fgtr', 'br32-', 'br_32',   # wrong length, start from digit, wrong end or char inside name
+    ].each do |iname|
+
+      it "should be failed for name #{iname}" do
+        expect { described_class.new({
+          :name   => "#{iname}",
+        })}.to raise_error(Puppet::ResourceError, /Wrong\s+bridge\s+name/)
+      end
+
+    end
+  end
+end
+# vim: set ts=2 sw=2 et


### PR DESCRIPTION
another type network interface.
i.e. old and new ethernet names, infiniband cards, wifi cards, etc...

FUEL-Change-Id: I55383cdb59bead345f0127b826ec4d8a127b34a8
Closes: #111