### PR TITLE
Fix config files for OVS bridges and ports

### DIFF
--- a/lib/puppetx/l23_utils.rb
+++ b/lib/puppetx/l23_utils.rb
@@ -23,9 +23,14 @@ module L23network
     end
   end
 
+  def self.get_normalized_bridges_order(bridges)
+    bridges[0..1].map{|s| s.to_s}.sort()
+  end
+
   def self.get_patch_name(bridges)
     # bridges should be an array of two string
-    "patch__#{bridges.map{|s| s.to_s}.sort.join('--')}"
+    bridges_sorted = get_normalized_bridges_order(bridges)
+    "patch__#{bridges_sorted.join('--')}"
   end
 
   def self.lnx_jack_name_len
@@ -43,14 +48,16 @@ module L23network
     elsif bridges.is_a? Array and bridges.length==1
       jj = [bridges[0],bridges[0]]
     else
-      jj = bridges[0..1]
+      jj = bridges
     end
     base_name=get_base_name_for_jacks(jj)
     return "#{base_name}-#{num}"
   end
 
   def self.get_pair_of_jack_names(bridges)
-    [get_jack_name(bridges,0), get_jack_name(bridges,1)]
+    # we need normalize here, because indexes used below
+    bridges_sorted = get_normalized_bridges_order(bridges)
+    [get_jack_name(bridges_sorted,0), get_jack_name(bridges_sorted,1)]
   end
 
 # def self.reccursive_merge_hash(a,b)

--- a/manifests/l2/bond_interface.pp
+++ b/manifests/l2/bond_interface.pp
@@ -17,6 +17,8 @@ define l23network::l2::bond_interface (
   } else {
     $master = $bond
     $slave  = true
+    L2_port[$name] -> L2_bond[$bond]
+    L23_stored_config[$name] -> L23_stored_config[$bond]
   }
 
   if ! defined(L23network::L2::Port[$name]) {
@@ -38,7 +40,5 @@ define l23network::l2::bond_interface (
       slave    => $slave
     }
   }
-  L2_port[$name] -> L2_bond[$bond]
-  L23_stored_config[$name] -> L23_stored_config[$bond]
 }
 ###

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bond_lacp
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bond_lacp
@@ -1,3 +1,4 @@
+allow-br0 bond_lacp
 iface bond_lacp inet manual
   mtu 9000
   ovs_bonds eth2 eth3

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge-with-ports
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge-with-ports
@@ -1,0 +1,5 @@
+auto br8
+allow-ovs br8
+iface br8 inet manual
+  ovs_type OVSBridge
+  ovs_ports ttt0 ttt1

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-port
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-port
@@ -1,3 +1,4 @@
+auto ttt0
 allow-br9 ttt0
 iface ttt0 inet manual
   mtu 6000

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bond__spec.rb
@@ -80,6 +80,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       subject { providers[:bond_lacp] }
       let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
       it { expect(cfg_file).not_to match(/auto\s+bond_lacp/) }
+      it { expect(cfg_file).to match(/allow-br0\s+bond_lacp/) }
       it { expect(cfg_file).to match(/iface\s+bond_lacp\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/mtu\s+9000/) }
       it { expect(cfg_file).to match(/ovs_bonds\s+eth2\s+eth3/) }
@@ -89,7 +90,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/ovs_options.+other_config:lacp-time=fast/) }
       it { expect(cfg_file).to match(/ovs_options.+other_config:bond-miimon-interval=50/) }
       it { expect(cfg_file).to match(/ovs_options.+lacp=active/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
@@ -73,12 +73,12 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
     context 'format file' do
       subject { providers[:br9] }
       let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
-      it { expect(cfg_file).not_to match(/auto\s+br9/) }
+      it { expect(cfg_file).to match(/auto\s+br9/) }
       it { expect(cfg_file).to match(/allow-ovs\s+br9/) }
       it { expect(cfg_file).to match(/iface\s+br9\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSBridge/) }
       it { expect(cfg_file).to match(/mtu\s+9000/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do

--- a/spec/unit/puppet/provider/l2_patch/ovs_patch__spec.rb
+++ b/spec/unit/puppet/provider/l2_patch/ovs_patch__spec.rb
@@ -87,14 +87,14 @@ describe Puppet::Type.type(:l2_patch).provider(:ovs) do
       provider_br2.class.stubs(:iproute).with().returns(true)
       provider_br2.class.stubs(:iproute).with('link', 'set', 'up', 'dev', 'br2').returns(true)
       provider_br2.class.stubs(:brctl).with('addbr', 'br2').returns(true)
-      provider_patch.class.stubs(:brctl).with('addif', 'br2', 'p_a0ad117b-0').returns(true)
+      provider_patch.class.stubs(:brctl).with('addif', 'br2', 'p_39a440c1-0').returns(true)
       provider_patch.class.stubs(:vsctl).with(
-        '--may-exist', 'add-port', 'br1', 'p_a0ad117b-0', '--', 'set', 'Interface', 'p_a0ad117b-0', 'type=internal'
+        '--may-exist', 'add-port', 'br1', 'p_39a440c1-0', '--', 'set', 'Interface', 'p_39a440c1-0', 'type=internal'
       ).returns(true)
       File.stubs(:directory?).with('/sys/class/net/br2/bridge').returns(true)
       provider_patch.class.stubs(:get_lnx_port_bridges_pairs).with().returns({})
       provider_patch.class.stubs(:get_bridges_order_for_patch).with(['br1','br2']).returns(['br1','br2'])
-      provider_patch.class.stubs(:iproute).with('link', 'set', 'up', 'dev', 'p_a0ad117b-0').returns(true)
+      provider_patch.class.stubs(:iproute).with('link', 'set', 'up', 'dev', 'p_39a440c1-0').returns(true)
     end
 
     it "Just create two bridges and connect it by patchcord" do


### PR DESCRIPTION
This patchset implements:
* interface's config files more correspond to: http://www.opencloudblog.com/?p=240
* add usage of 'ovs_ports' option in bridges config file
* add usage of 'auto' option for OVS bridges and ports
* add tests for OVS bridge with two ports included
* fix issue when brigdes may be presented in wrong order

Closes: #114