### PR TITLE
Fix OVS bond for l23network module

### DIFF
--- a/lib/puppet/provider/l2_bond/lnx.rb
+++ b/lib/puppet/provider/l2_bond/lnx.rb
@@ -82,15 +82,15 @@ Puppet::Type.type(:l2_bond).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
           rm_slave_list = runtime_slave_ports - @property_flush[:slaves]
           debug("Remove '#{rm_slave_list.join(',')}' ports from bond '#{@resource[:bond]}'")
           rm_slave_list.each do |slave|
-            iproute('link', 'set', 'dev', slave, 'down')  # need by kernel requirements by design. undocumented :(
+            iproute('link', 'set', 'down', 'dev', slave)  # need by kernel requirements by design. undocumented :(
             File.open("/sys/class/net/#{@resource[:bond]}/bonding/slaves", "a") {|f| f << "-#{slave}"}
           end
           # add interfaces to bond
           (@property_flush[:slaves] - runtime_slave_ports).each do |slave|
-            iproute('link', 'set', 'dev', slave, 'down')  # need by kernel requirements by design. undocumented :(
+            iproute('link', 'set', 'down', 'dev', slave)  # need by kernel requirements by design. undocumented :(
             debug("Add interface '#{slave}' to bond '#{@resource[:bond]}'")
             File.open("/sys/class/net/#{@resource[:bond]}/bonding/slaves", "a") {|f| f << "+#{slave}"}
-            iproute('link', 'set', 'dev', slave, 'up')
+            iproute('link', 'set', 'up', 'dev', slave)
           end
         end
       end
@@ -135,7 +135,7 @@ Puppet::Type.type(:l2_bond).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
         #
         # remove interface from old bridge
         runtime_bond_state  = !self.class.get_iface_state(@resource[:bond]).nil?
-        iproute('--force', 'link', 'set', 'dev', @resource[:bond], 'down')
+        iproute('--force', 'link', 'set', 'down', 'dev', @resource[:bond])
         if ! port_bridges_hash[@resource[:bond]].nil?
           br_name = port_bridges_hash[@resource[:bond]][:bridge]
           if br_name != @resource[:bond]
@@ -163,11 +163,11 @@ Puppet::Type.type(:l2_bond).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
             #pass
           end
         end
-        iproute('link', 'set', 'dev', @resource[:bond], 'up') if runtime_bond_state
+        iproute('link', 'set', 'up', 'dev', @resource[:bond]) if runtime_bond_state
         debug("Change bridge")
       end
       if @property_flush[:onboot]
-        iproute('link', 'set', 'dev', @resource[:bond], 'up')
+        iproute('link', 'set', 'up', 'dev', @resource[:bond])
       end
       if !['', 'absent'].include? @property_flush[:mtu].to_s
         self.class.set_mtu(@resource[:bond], @property_flush[:mtu])

--- a/lib/puppet/provider/l2_port/lnx.rb
+++ b/lib/puppet/provider/l2_port/lnx.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:l2_port).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
       end
       #
       # FLUSH changed properties
-      if @property_flush.has_key? :bond_master
+      if @property_flush.has_key? :bond_master and @property_flush[:bond_master] != :absent
         bond = @old_property_hash[:bond_master]
         if self.class.ipaddr_exist? @resource[:interface]
           # remove all IP addresses from member of bond. This should be done on device in UP state
@@ -111,7 +111,7 @@ Puppet::Type.type(:l2_port).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
         #Flush ipaddr and routes for interface, thah adding to the bridge
         iproute('route', 'flush', 'dev', @resource[:interface])
         iproute('addr', 'flush', 'dev', @resource[:interface])
-        iproute('--force', 'link', 'set', 'dev', @resource[:interface], 'down')
+        iproute('--force', 'link', 'set', 'down', 'dev', @resource[:interface])
         # remove interface from old bridge
         if ! port_bridges_hash[@resource[:interface]].nil?
           br_name = port_bridges_hash[@resource[:interface]][:bridge]
@@ -146,7 +146,7 @@ Puppet::Type.type(:l2_port).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
             #pass
           end
         end
-        iproute('link', 'set', 'dev', @resource[:interface], 'up')
+        iproute('link', 'set', 'up', 'dev', @resource[:interface])
         debug("Change bridge")
       end
       if @property_flush.has_key? :ethtool and @property_flush[:ethtool].is_a? Hash
@@ -172,7 +172,10 @@ Puppet::Type.type(:l2_port).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
       if ! @property_flush[:onboot].nil?
         # Should be after bond, because interface may auto-upped while added to the bond
         debug("Setup UP state for interface '#{@resource[:interface]}'.")
-        iproute('link', 'set', 'dev', @resource[:interface], 'up')
+        # Up parent interface if this is vlan port
+        iproute('link', 'set', 'up', 'dev', @resource[:vlan_dev]) if @resource[:vlan_dev]
+        # Up port
+        iproute('link', 'set', 'up', 'dev', @resource[:interface])
       end
       if !['', 'absent'].include? @property_flush[:mtu].to_s
         self.class.set_mtu(@resource[:interface], @property_flush[:mtu])

--- a/manifests/l3/ifconfig.pp
+++ b/manifests/l3/ifconfig.pp
@@ -193,8 +193,9 @@ define l23network::l3::ifconfig (
     if !defined(L23network::L2::Port[$interface]) and !defined(L23network::L2::Bond[$interface]) and !defined(L23network::L2::Bridge[$interface]) {
       l23network::l2::port { $interface: }
       L23network::L2::Port[$interface] -> L3_ifconfig[$interface]
+    } elsif defined(L23network::L2::Bridge[$interface]) {
+      L23network::L2::Bridge[$interface] -> L3_ifconfig[$interface]
     }
-
 
     if ! defined (L23_stored_config[$interface]) {
       l23_stored_config { $interface:

--- a/spec/classes/bond__spec.rb
+++ b/spec/classes/bond__spec.rb
@@ -110,6 +110,7 @@ network_scheme:
       interfaces:
         - eth2
         - eth3
+      bridge: some-bridge
       mtu: 4000
       bond_properties:
         mode: balance-rr

--- a/spec/classes/bond_with_subinterfaces__spec.rb
+++ b/spec/classes/bond_with_subinterfaces__spec.rb
@@ -101,6 +101,7 @@ network_scheme:
       interfaces:
         - eth2.101
         - eth3.101
+      bridge: br-bond23
       bond_properties:
         mode: balance-rr
       provider: ovs
@@ -141,6 +142,7 @@ end
         'provider' => 'ovs',
         'ensure' => 'present',
         'slaves' => ['eth2.101', 'eth3.101'],
+        'bridge' => 'br-bond23',
       })
     end
 

--- a/spec/classes/transformations_and_endpoints_ordering__spec.rb
+++ b/spec/classes/transformations_and_endpoints_ordering__spec.rb
@@ -107,6 +107,7 @@ network_scheme:
       interfaces:
         - eth2
         - eth3
+      bridge: br-bond0
       bond_properties:
         mode: balance-rr
   endpoints:
@@ -194,6 +195,7 @@ network_scheme:
       interfaces:
         - eth2
         - eth3
+      bridge: some-bridge
       bond_properties:
         mode: balance-rr
       provider: ovs


### PR DESCRIPTION
* Add lacp states calculation
* Rise error if bridge is not defined for ovs provider
* Add bridge creation for ovs bonds
* Add ordering for l3::ifconfig
* Up parent interface for vlan port
* Correct condition for bond port

FUEL-Change-Id: I463368e6d6a48cf1a92113b4fc75cc87ebf08020
Closes: #125