### PR TITLE
Fix problem with bond on subinterfaces

### DIFF
--- a/lib/puppet/provider/l2_port/lnx.rb
+++ b/lib/puppet/provider/l2_port/lnx.rb
@@ -98,7 +98,10 @@ Puppet::Type.type(:l2_port).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
           # port no more member of any bonds
           @property_flush[:port_type] = nil
         end
-        iproute('--force', 'link', 'set', 'up', 'dev', @resource[:interface])
+        # Up parent interface if this is vlan port
+        iproute('link', 'set', 'up', 'dev', @resource[:vlan_dev]) if @resource[:vlan_dev]
+        # Up port
+        iproute('link', 'set', 'up', 'dev', @resource[:interface])
       end
       if @property_flush.has_key? :bridge
         # get actual bridge-list. We should do it here,


### PR DESCRIPTION
During adding subinterface to existing bond parent interface can be
down that is why we get an error "RTNETLINK answers: Network is down"

FUEL-Change-Id: Iea2ae32beffcc83b8ff2537924e87b01b47658cf
Closes: #127