### PR TITLE
Fix l3 clear route provider to work with sub-IFs

### DIFF
--- a/lib/puppet/parser/functions/generate_network_config.rb
+++ b/lib/puppet/parser/functions/generate_network_config.rb
@@ -162,7 +162,7 @@ Puppet::Parser::Functions::newfunction(:generate_network_config, :type => :rvalu
         #Clear default gateway
         #todo(sv): remove it here and include to l3_ifconfig resource
         if resource_properties['gateway']
-          l3_resource_properties = { 'ensure' => 'absent', 'destination' => 'default', 'gateway' => resource_properties['gateway'] }
+          l3_resource_properties = { 'ensure' => 'absent', 'destination' => 'default', 'gateway' => resource_properties['gateway'], 'interface' => endpoint_name }
           l3_resource_properties['metric'] = resource_properties['gateway_metric'] if resource_properties['gateway_metric']
           gateway_name = L23network.get_route_resource_name('default', l3_resource_properties['metric'])
           if previous

--- a/lib/puppet/type/l3_clear_route.rb
+++ b/lib/puppet/type/l3_clear_route.rb
@@ -28,6 +28,15 @@ Puppet::Type.newtype(:l3_clear_route) do
 
     end
 
+    newproperty(:interface) do
+      desc "interface of the route"
+      validate do |val|
+        if not val =~ /^[a-z_][\w\.\-]*[0-9a-z]$/
+          fail("Invalid interface name: '#{val}'")
+        end
+      end
+    end
+
     newproperty(:metric) do
       desc "Route metric"
       newvalues(/^\d+$/, :absent, :none, :undef, :nil)


### PR DESCRIPTION
This fix ensures that l3 route has been cleared
before we try to set default route. This is very
important for nodes that
do not have default gateway configured at all.

This issue affects environments with subinterfaces
for admin interface as we cannot add new route
through new interface in runtime as we already
have default gateway through the different interface
which is eth0/eth1 almost each time.

E.g.

default via 10.109.17.1 dev eth1

should become

default via 10.109.17.1 dev br-fw-admin

But l3_clear_route does not understand that these routes
are different and thus does not clear the first one.
This in fact leads to inability to set default route
by puppet l3_ifconfig provider. Look into
https://bugs.launchpad.net/fuel/+bug/1447638 for more
details.

This fix adds 'interface' property into l3_clear_route
puppet type which is a hacky w/a for l23network ip route
management.

It also ensures that if route iface is changed we need to
recreate the route.

Author: Vladimir Kuklin <vkuklin@mirantis.com>
FUEL-Change-Id: I44e45ce1e13a4836552b95440cdfb706a5c177c5

Closes: #140