### PR TITLE
Do not create config file for ovs2ovs patchcord

### DIFF
--- a/lib/puppet/parser/functions/get_provider_for.rb
+++ b/lib/puppet/parser/functions/get_provider_for.rb
@@ -1,24 +1,13 @@
-
 module Puppet::Parser::Functions
   newfunction(:get_provider_for, :type => :rvalue, :doc => <<-EOS
-  Get the default provider of a type
+  Get resource provider by given name and type
   EOS
   ) do |argv|
-    type_name = argv[0]
-    res_name = argv[1]
+    type_name = argv[0].to_s
+    resource_name = argv[1].to_s
     fail('No type name provided!') if ! type_name
-    Puppet::Type.loadall()
-    type_name = type_name.capitalize.to_sym
-    return 'undef' if ! Puppet::Type.const_defined? type_name
-    type = Puppet::Type.const_get type_name
-# require 'pry'
-# binding.pry
-    type.loadall()
-    rv = type.instances.select{|i| i.name.to_s.downcase == res_name.to_s.downcase}.map{|j| j[:provider].to_s}
-# require 'pry'
-# binding.pry
-    rv = rv[0]
-    debug("Provider for '#{type_name}[#{res_name}]' is a '#{rv}'.")
-    return rv
+    # type.loadall()
+    resource = catalog.resources.select{|res| res.type.to_s==type_name and res.title.to_s==resource_name }[0]
+    ( resource.nil?  ?  nil  :  resource[:provider].to_s )
   end
 end

--- a/spec/classes/ovs2lnx__ovs_patch__spec.rb
+++ b/spec/classes/ovs2lnx__ovs_patch__spec.rb
@@ -30,7 +30,6 @@ eof
 end
 
   context 'Patch between OVS and LNX bridges.' do
-    let(:title) { 'Centos has delay for port after boot' }
     let(:facts) {
       {
         :osfamily => 'Debian',
@@ -116,7 +115,6 @@ end
         'provider'       => 'ovs_ubuntu'
       })
     end
-
   end
 
 end

--- a/spec/classes/ovs2ovs__ovs_patch__spec.rb
+++ b/spec/classes/ovs2ovs__ovs_patch__spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+describe 'l23network::examples::run_network_scheme', :type => :class do
+let(:network_scheme) do
+<<eof
+---
+network_scheme:
+  version: 1.1
+  provider: lnx
+  interfaces:
+    eth1: {}
+  transformations:
+    - action: add-br
+      name: br-ovs2
+      provider: ovs
+    - action: add-br
+      name: br-ovs1
+      provider: ovs
+    - action: add-patch
+      bridges:
+        - br-ovs2
+        - br-ovs1
+      provider: ovs
+  endpoints: {}
+  roles: {}
+eof
+end
+
+  context 'Patch between two OVS bridges.' do
+    let(:facts) {
+      {
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :kernel => 'Linux',
+        :l23_os => 'ubuntu',
+        :l3_fqdn_hostname => 'stupid_hostname',
+      }
+    }
+
+    let(:params) do {
+      :settings_yaml => network_scheme,
+    } end
+
+    get_provider_for = {}
+    before(:each) do
+      if ENV['SPEC_PUPPET_DEBUG']
+        Puppet::Util::Log.level = :debug
+        Puppet::Util::Log.newdestination(:console)
+      end
+
+      Puppet::Parser::Functions.newfunction(:get_provider_for, :type => :rvalue) {
+        |args| get_provider_for.call(args[0], args[1])
+      }
+
+      get_provider_for.stubs(:call).with('L2_bridge', 'br-ovs1').returns('ovs')
+      get_provider_for.stubs(:call).with('L2_bridge', 'br-ovs2').returns('ovs')
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_l23_stored_config('br-ovs1').with({
+        'ensure'   => 'present',
+        'provider' => 'ovs_ubuntu'
+      })
+    end
+
+    it do
+      should contain_l23_stored_config('br-ovs2').with({
+        'ensure'   => 'present',
+        'provider' => 'ovs_ubuntu'
+      })
+    end
+
+    it do
+      should contain_l2_bridge('br-ovs1').with({
+        'ensure'   => 'present',
+        'provider' => 'ovs'
+      })
+    end
+
+    it do
+      should contain_l2_bridge('br-ovs2').with({
+        'ensure'   => 'present',
+        'provider' => 'ovs'
+      })
+    end
+
+    it do
+      should contain_l2_patch('patch__br-ovs1--br-ovs2').with({
+        'ensure'   => 'present',
+        'bridges'  => ['br-ovs1', 'br-ovs2'],
+        'vlan_ids' => ['0', '0'],
+        'provider' => 'ovs'
+      })
+    end
+
+    it do
+      should contain_l2_patch('patch__br-ovs1--br-ovs2').with_jacks(['p_f277dc2b-0', 'p_f277dc2b-1'])
+    end
+
+    it do
+      should_not contain_l23_stored_config('p_f277dc2b-0')
+    end
+  end
+
+end
+
+# vim: set ts=2 sw=2 et


### PR DESCRIPTION
Ubuntu with OVS < 2.4 does not support such configs at all.

Co-Authored: Stanislav Makar <smakar@mirantis.com> 

FUEL-Change-Id: I9161e282f285dffc018a9d7d3fe91cb3760486ad

Closes: #144