### PR TITLE
Disable/enable hotplug for network interfaces

### DIFF
--- a/lib/puppet/provider/disable_hotplug/lnx.rb
+++ b/lib/puppet/provider/disable_hotplug/lnx.rb
@@ -1,0 +1,51 @@
+Puppet::Type.type(:disable_hotplug).provide(:lnx) do
+  defaultfor :osfamily => :linux
+  commands   :udevadm  =>  'udevadm'
+
+  def self.prefetch(resources)
+    instances.each do |provider|
+      name = provider.name.to_s
+      next unless resources.key? name
+      resources[name].provider = provider
+    end
+  end
+
+  def self.instances
+   file_exist = File.exist?('/run/disable-network-interface-hotplug') or File.exist?('/var/run/disable-network-interface-hotplug')
+   result = []
+   if file_exist
+     result << new({ :name => 'global' , :ensure => :present })
+   else
+     result << new({ :name => 'global' , :ensure => :absent })
+   end
+   return result
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    self.class.instances.each do |provider|
+      if provider.name == 'global'
+         udevadm('control', '--stop-exec-queue')
+         if File.exist?('/run')
+           FileUtils.touch('/run/disable-network-interface-hotplug')
+         else
+           FileUtils.touch('/var/run/disable-network-interface-hotplug')
+         end
+      end
+    end
+  end
+
+  def destroy
+    info("\n Does not support 'ensure=absent' \n It could be 'ensure=present' ONLY!!! ")
+  end
+
+  def flush
+    debug 'Call: flush'
+  end
+
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/enable_hotplug/lnx.rb
+++ b/lib/puppet/provider/enable_hotplug/lnx.rb
@@ -1,0 +1,51 @@
+Puppet::Type.type(:enable_hotplug).provide(:lnx) do
+  defaultfor :osfamily => :linux
+  commands   :udevadm  => 'udevadm'
+
+  def self.prefetch(resources)
+    instances.each do |provider|
+      name = provider.name.to_s
+      next unless resources.key? name
+      resources[name].provider = provider
+    end
+  end
+
+  def self.instances
+   file_exist = File.exist?('/run/disable-network-interface-hotplug') or File.exist?('/var/run/disable-network-interface-hotplug')
+   result = []
+   if file_exist
+     result << new({ :name => 'global' , :ensure => :absent })
+   else
+     result << new({ :name => 'global' , :ensure => :present })
+   end
+   return result
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    self.class.instances.each do |provider|
+      if provider.name == 'global'
+         if File.exist?('/run/disable-network-interface-hotplug')
+           FileUtils.rm('/run/disable-network-interface-hotplug')
+         else
+           FileUtils.rm('/var/run/disable-network-interface-hotplug')
+         end
+         udevadm('control', '--start-exec-queue')
+      end
+    end
+  end
+
+  def destroy
+    info("\n Does not support 'ensure=absent' \n It could be 'ensure=present' ONLY!!! ")
+  end
+
+  def flush
+    debug 'Call: flush'
+  end
+
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/type/disable_hotplug.rb
+++ b/lib/puppet/type/disable_hotplug.rb
@@ -1,0 +1,11 @@
+Puppet::Type.newtype(:disable_hotplug) do
+    @doc = "Disables the network interface hotplug."
+    desc @doc
+
+    ensurable
+
+    newparam(:name)
+
+
+end
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/type/enable_hotplug.rb
+++ b/lib/puppet/type/enable_hotplug.rb
@@ -1,0 +1,11 @@
+Puppet::Type.newtype(:enable_hotplug) do
+    @doc = "Enables the network interface hotplug."
+    desc @doc
+
+    ensurable
+
+    newparam(:name)
+
+
+end
+# vim: set ts=2 sw=2 et :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,10 @@
 #   (optional) The state of used packages
 #   Defaults to 'present'
 #
+# [*disable_hotplug*]
+#   (optional) Enables to disable hotplug system temporarily during network configuration
+#   Defaults to true
+#
 class l23network (
   $ensure_package            = 'present',
   $use_lnx                   = true,
@@ -21,6 +25,7 @@ class l23network (
   $ovs_modname               = undef,
   $ovs_datapath_package_name = undef,
   $ovs_common_package_name   = undef,
+  $disable_hotplug           = true,
 ){
 
   include stdlib
@@ -72,4 +77,21 @@ class l23network (
   Anchor['l23network::l2::init'] -> Anchor['l23network::init']
   anchor { 'l23network::init': }
 
+  if $disable_hotplug {
+    disable_hotplug { 'global':
+      ensure => 'present',
+    }
+    Disable_hotplug['global'] -> Anchor['l23network::init']
+
+    enable_hotplug { 'global':
+      ensure => 'present',
+    }
+    Disable_hotplug['global'] -> Enable_hotplug['global']
+    L2_port<||>               -> Enable_hotplug['global']
+    L2_bridge<||>             -> Enable_hotplug['global']
+    L2_bond<||>               -> Enable_hotplug['global']
+    L3_ifconfig<||>           -> Enable_hotplug['global']
+    L23_stored_config<||>     -> Enable_hotplug['global']
+    L3_route<||>              -> Enable_hotplug['global']
+  }
 }

--- a/spec/classes/l23network_init__spec.rb
+++ b/spec/classes/l23network_init__spec.rb
@@ -72,6 +72,14 @@ describe 'l23network', :type => :class do
       }).that_comes_before('Anchor[l23network::l2::init]')
     end
 
+    it do
+      should contain_disable_hotplug('global')
+    end
+
+    it do
+      should contain_enable_hotplug('global').that_requires('Disable_hotplug[global]')
+    end
+
   end
 
   context 'when removing packages of the l23network module' do
@@ -117,5 +125,4 @@ describe 'l23network', :type => :class do
   end
 
 end
-
-###
+# vim: set ts=2 sw=2 et

--- a/spec/classes/transformations_and_endpoints_ordering__spec.rb
+++ b/spec/classes/transformations_and_endpoints_ordering__spec.rb
@@ -85,6 +85,14 @@ end
       should contain_L23network__L3__Ifconfig('eth3.103').that_requires("L23network::L2::Port[eth3.103]")
     end
 
+    it do
+      should contain_disable_hotplug('global')
+    end
+
+    it do
+      should contain_enable_hotplug('global').that_requires('L23_stored_config[eth3.103]')
+    end
+
   end
 end
 

--- a/spec/defines/l2_bridge__spec.rb
+++ b/spec/defines/l2_bridge__spec.rb
@@ -200,6 +200,7 @@ describe 'l23network::l2::bridge', :type => :define do
         'ensure'       => 'present',
         'use_ovs'      => true,
         'external_ids' => { 'bridge-id' => 'br-floating' },
+        'stp'          => nil,
         'provider'     => nil,
       }).that_requires('L23_stored_config[br-floating]')
     end
@@ -233,6 +234,7 @@ describe 'l23network::l2::bridge', :type => :define do
         'ensure'       => 'present',
         'use_ovs'      => true,
         'external_ids' => { 'bridge-id' => 'br-floating' },
+        'stp'          => nil,
         'provider'     => nil,
       }).that_requires('L23_stored_config[br-floating]')
     end

--- a/spec/unit/puppet/provider/disable_hotplug/lnx__spec.rb
+++ b/spec/unit/puppet/provider/disable_hotplug/lnx__spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:disable_hotplug).provider(:lnx)
+
+describe provider_class do
+  let(:name) { 'global' }
+
+  let(:resource) do
+    Puppet::Type.type(:disable_hotplug).new(
+      :name        => name,
+      :ensure      => 'present',
+    )
+  end
+
+  let(:provider) do
+    provider = provider_class.new
+    provider.resource = resource
+    provider
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  it 'Disable hotplug /run' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/run').returns(true)
+    provider.class.stubs(:udevadm).with('control', '--stop-exec-queue').returns(0)
+    FileUtils.stubs(:touch).with('/run/disable-network-interface-hotplug').returns(0)
+    provider.create
+  end
+
+  it 'Disable hotplug /var/run' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/run').returns(false)
+    provider.class.stubs(:udevadm).with('control', '--stop-exec-queue').returns(0)
+    FileUtils.stubs(:touch).with('/var/run/disable-network-interface-hotplug').returns(0)
+    provider.create
+  end
+
+
+  it 'File create error' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/run').returns(true)
+    provider.class.stubs(:udevadm).with('control', '--stop-exec-queue').returns(0)
+    FileUtils.stubs(:touch).with('/run/disable-network-interface-hotplug').raises(Puppet::ExecutionFailure,'')
+    expect{provider.create}.to raise_error(Puppet::ExecutionFailure)
+  end
+
+  it 'Udevadm error' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/run').returns(true)
+    provider.class.stubs(:udevadm).with('control', '--stop-exec-queue').raises(Puppet::ExecutionFailure,'')
+    expect{provider.create}.to raise_error(Puppet::ExecutionFailure)
+  end
+
+  it 'Do nothing' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(true)
+    provider.class.expects(:udevadm).with('control', '--stop-exec-queue').never
+  end
+
+end
+
+# vim: set ts=2 sw=2 et

--- a/spec/unit/puppet/provider/enable_hotplug/lnx__spec.rb
+++ b/spec/unit/puppet/provider/enable_hotplug/lnx__spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:enable_hotplug).provider(:lnx)
+
+describe provider_class do
+  let(:name) { 'global' }
+
+  let(:resource) do
+    Puppet::Type.type(:enable_hotplug).new(
+      :name        => name,
+      :ensure      => 'present',
+    )
+  end
+
+  let(:provider) do
+    provider = provider_class.new
+    provider.resource = resource
+    provider
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  it 'Enable hotplug /run' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(true)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    FileUtils.stubs(:rm).with('/run/disable-network-interface-hotplug').returns(0)
+    provider.class.stubs(:udevadm).with('control', '--start-exec-queue').returns(0)
+    provider.create
+  end
+
+  it 'Enable hotplug /var/run' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(true)
+    FileUtils.stubs(:rm).with('/var/run/disable-network-interface-hotplug').returns(0)
+    provider.class.stubs(:udevadm).with('control', '--start-exec-queue').returns(0)
+    provider.create
+  end
+
+  it 'Udevadm error' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(true)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    FileUtils.stubs(:rm).with('/run/disable-network-interface-hotplug').returns(0)
+    provider.class.stubs(:udevadm).with('control', '--start-exec-queue').raises(Puppet::ExecutionFailure,'')
+    expect{provider.create}.to raise_error(Puppet::ExecutionFailure)
+  end
+
+  it 'File remove error' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(true)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    FileUtils.stubs(:rm).with('/run/disable-network-interface-hotplug').raises(Puppet::ExecutionFailure,'')
+    expect{provider.create}.to raise_error(Puppet::ExecutionFailure)
+  end
+
+  it 'Do nothing' do
+    File.stubs(:exist?).with('/run/disable-network-interface-hotplug').returns(false)
+    File.stubs(:exist?).with('/var/run/disable-network-interface-hotplug').returns(false)
+    provider.expects(:udevadm).with('control', '--start-exec-queue').never
+  end
+
+end
+
+# vim: set ts=2 sw=2 et


### PR DESCRIPTION
Disable/enable hotplug for network interfaces during network configuration.
Ubuntu and CentOS have special jobs which up interface automatically when
it appears in system. During puppet run we do not manage interface
configurations completely. It leads to not understandable errors and hence
long-time debugging.

FUEL-Change-Id: I9f3a7a92c1cdc73bc145cd95af2fa9defa9a6efc
Closes: #63