### PR TITLE
Remove duplicated constant MAX_BR_NAME_LENGTH

### DIFF
--- a/lib/puppet/type/k_mod.rb
+++ b/lib/puppet/type/k_mod.rb
@@ -4,8 +4,6 @@ Puppet::Type.newtype(:k_mod) do
 
     ensurable
 
-    MAX_BR_NAME_LENGTH = 15
-
     newparam(:module) do
       isnamevar
       desc "Module name"


### PR DESCRIPTION
This change removes the MAX_BR_NAME_LENGTH from k_mod as it is also
defined and used in l2_bridge.

Author: Alex Schultz <aschultz@mirantis.com>

FUEL-Change-Id: I23c88ebd947db4480c6c9322bd1fafa14ca2c540

Closes: #168