### PR TITLE
Add support of CentOS7/RedHat7 to l23network

### DIFF
--- a/lib/facter/l23_os.rb
+++ b/lib/facter/l23_os.rb
@@ -4,15 +4,24 @@
 #
 Facter.add(:l23_os) do
   setcode do
-    case Facter.value(:osfamily)
-      when /(?i)darwin/
-        'osx'
-      when /(?i)debian/
+    case Facter.value(:operatingsystem)
+      when /(?i)ubuntu/
         #todo: separate upstart and systemd based
         'ubuntu'
+      when /(?i)centos/
+        case Facter.value(:operatingsystemmajrelease)
+          when /6/
+            'centos6'
+          when /7/
+            'centos7'
+        end
       when /(?i)redhat/
-        #todo: separate centos6 and centos7
-        'centos6'
+        case Facter.value(:operatingsystemmajrelease)
+          when /7/
+            'redhat7'
+        end
+      when /(?i)darwin/
+        'osx'
     end
   end
 end

--- a/lib/puppet/provider/l23_stored_config/lnx_centos7.rb
+++ b/lib/puppet/provider/l23_stored_config/lnx_centos7.rb
@@ -1,17 +1,16 @@
 require 'puppetx/filemapper'
 require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_centos')
 
-Puppet::Type.type(:l23_stored_config).provide(:lnx_centos6, :parent => Puppet::Provider::L23_stored_config_centos) do
+Puppet::Type.type(:l23_stored_config).provide(:lnx_centos7, :parent => Puppet::Provider::L23_stored_config_centos) do
 
   include PuppetX::FileMapper
 
-  confine    :l23_os => :centos6
-  defaultfor :l23_os => :centos6
+  confine    :l23_os => :centos7
+  defaultfor :l23_os => :centos7
 
   has_feature :provider_options
 
   self.unlink_empty_files = true
 
 end
-
 # vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l23_stored_config/lnx_redhat7.rb
+++ b/lib/puppet/provider/l23_stored_config/lnx_redhat7.rb
@@ -1,17 +1,16 @@
 require 'puppetx/filemapper'
 require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_centos')
 
-Puppet::Type.type(:l23_stored_config).provide(:lnx_centos6, :parent => Puppet::Provider::L23_stored_config_centos) do
+Puppet::Type.type(:l23_stored_config).provide(:lnx_redhat7, :parent => Puppet::Provider::L23_stored_config_centos) do
 
   include PuppetX::FileMapper
 
-  confine    :l23_os => :centos6
-  defaultfor :l23_os => :centos6
+  confine    :l23_os => :redhat7
+  defaultfor :l23_os => :redhat7
 
   has_feature :provider_options
 
   self.unlink_empty_files = true
 
 end
-
 # vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l23_stored_config/ovs_centos7.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_centos7.rb
@@ -1,11 +1,11 @@
 require 'puppetx/filemapper'
 require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_ovs_centos')
 
-Puppet::Type.type(:l23_stored_config).provide(:ovs_centos6, :parent => Puppet::Provider::L23_stored_config_ovs_centos) do
+Puppet::Type.type(:l23_stored_config).provide(:ovs_centos7, :parent => Puppet::Provider::L23_stored_config_ovs_centos) do
 
   include PuppetX::FileMapper
 
-  confine :l23_os => :centos6
+  confine :l23_os => :centos7
 
   has_feature :provider_options
 

--- a/lib/puppet/provider/l23_stored_config/ovs_redhat7.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_redhat7.rb
@@ -1,11 +1,12 @@
 require 'puppetx/filemapper'
 require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_ovs_centos')
 
-Puppet::Type.type(:l23_stored_config).provide(:ovs_centos6, :parent => Puppet::Provider::L23_stored_config_ovs_centos) do
+Puppet::Type.type(:l23_stored_config).provide(:ovs_redhat7, :parent => Puppet::Provider::L23_stored_config_ovs_centos) do
 
   include PuppetX::FileMapper
 
-  confine :l23_os => :centos6
+  confine    :l23_os => :redhat7
+  defaultfor :l23_os => :redhat7
 
   has_feature :provider_options
 

--- a/lib/puppet/provider/l23_stored_config_centos.rb
+++ b/lib/puppet/provider/l23_stored_config_centos.rb
@@ -1,7 +1,7 @@
 require 'puppetx/l23_ethtool_name_commands_mapping'
 require File.join(File.dirname(__FILE__), 'l23_stored_config_base')
 
-class Puppet::Provider::L23_stored_config_centos6 < Puppet::Provider::L23_stored_config_base
+class Puppet::Provider::L23_stored_config_centos < Puppet::Provider::L23_stored_config_base
 
   # @return [String] The path to network-script directory on redhat systems
   def self.script_directory

--- a/lib/puppet/provider/l23_stored_config_ovs_centos.rb
+++ b/lib/puppet/provider/l23_stored_config_ovs_centos.rb
@@ -1,0 +1,57 @@
+require File.join(File.dirname(__FILE__), '..','..','puppet/provider/l23_stored_config_centos')
+
+class Puppet::Provider::L23_stored_config_ovs_centos < Puppet::Provider::L23_stored_config_centos
+
+  def self.property_mappings
+    rv = super
+    rv.merge!({
+      :devicetype => 'DEVICETYPE',
+    })
+    return rv
+  end
+
+  def self.properties_fake
+    rv = super
+    rv.push(:devicetype)
+    return rv
+  end
+
+  #Dirty hack which writes config files for OVS
+  #bridges into /tmp directory
+  def select_file
+    if name == 'br-prv' or name == 'br-floating'
+      "/tmp/ifcfg-#{name}"
+    else
+      "#{self.class.script_directory}/ifcfg-#{name}"
+    end
+  end
+
+  def self.unmangle__if_type(provider, val)
+    if val == :bridge
+      val = :OVSBridge
+    else
+      val.to_s.capitalize.intern
+    end
+  end
+
+  def self.mangle__if_type(val)
+    if val == :OVSBridge
+      val = :bridge
+    else
+      val.to_s.downcase.intern
+    end
+  end
+
+  #Dirty hack which deletes OVS bridges from patch OVS
+  #interfaces
+  def self.unmangle__bridge(provider, val)
+    if val.length == 2
+      val.delete('br-prv') if val.include?('br-prv')
+      val.delete('br-floating') if val.include?('br-floating')
+      val
+    end
+  end
+
+end
+
+# vim: set ts=2 sw=2 et :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,7 @@ class l23network (
   Anchor['l23network::l2::init'] -> File<| title == "${::l23network::params::interfaces_file}" |>
 
   # Centos interface up-n-down scripts
-  if $::osfamily =~ /(?i)redhat/ {
+  if $::l23_os =~ /(?i:redhat|centos)/ {
     class{'::l23network::l2::centos_upndown_scripts': } -> Anchor['l23network::init']
     Anchor <| title == 'l23network::l2::centos_upndown_scripts' |> -> Anchor['l23network::init']
   }

--- a/manifests/l2/bond.pp
+++ b/manifests/l2/bond.pp
@@ -255,7 +255,7 @@ define l23network::l2::bond (
 
   }
 
-  if $::osfamily =~ /(?i)redhat/ {
+  if $::l23_os =~ /(?i:redhat|centos)/ {
     if $delay_while_up {
       file {"${::l23network::params::interfaces_dir}/interface-up-script-${bond}":
         ensure  => present,

--- a/manifests/l2/bridge.pp
+++ b/manifests/l2/bridge.pp
@@ -68,7 +68,7 @@ define l23network::l2::bridge (
     Anchor['l23network::init'] -> K_mod<||> -> L2_bridge<||>
   }
 
-  if $::osfamily =~ /(?i)redhat/ {
+  if $::l23_os =~ /(?i:redhat|centos)/ {
     if $delay_while_up {
       file {"${::l23network::params::interfaces_dir}/interface-up-script-${name}":
         ensure  => present,

--- a/manifests/l2/port.pp
+++ b/manifests/l2/port.pp
@@ -162,7 +162,7 @@ define l23network::l2::port (
     Anchor['l23network::init'] -> K_mod<||> -> L2_port<||>
   }
 
-  if $::osfamily =~ /(?i)redhat/ {
+  if $::l23_os =~ /(?i:redhat|centos)/ {
     if $delay_while_up {
       file {"${::l23network::params::interfaces_dir}/interface-up-script-${port_name}":
         ensure  => present,

--- a/manifests/l3/defaultroute.pp
+++ b/manifests/l3/defaultroute.pp
@@ -10,15 +10,15 @@ define l23network::l3::defaultroute (
 
   $exec_name = "Default route of ${name} metric ${metric}"
 
-  case $::osfamily {
-    /(?i)debian/: {
+  case $::l23_os {
+    /(?i)ubuntu/: {
         exec { $exec_name :
             path    => '/bin:/usr/bin:/sbin:/usr/sbin',
             command => "ip route replace default via ${gateway}",
             unless  => "netstat -r | grep -q 'default.*${gateway}'",
         }
     }
-    /(?i)redhat/: {
+    /(?i:redhat|centos)/: {
         Cfg <| name == $gateway |>
         if ! defined(Cfg[$gateway]) {
           cfg { $gateway:
@@ -36,7 +36,7 @@ define l23network::l3::defaultroute (
         }
     }
     default: {
-        fail("Unsupported OS: ${::osfamily}/${::operatingsystem}")
+        fail("Unsupported OS: ${::l23_os}/${::operatingsystem}")
     }
   }
 

--- a/manifests/l3/ifconfig.pp
+++ b/manifests/l3/ifconfig.pp
@@ -151,26 +151,6 @@ define l23network::l3::ifconfig (
     $def_gateway = undef
   }
 
-  # todo: re-implement later
-  # if $::osfamily =~ /(?i)redhat/ and ($ipaddr_aliases or $ethtool_lines) {
-  #   Anchor['l23network::init'] ->
-  #   file {"${::l23network::params::interfaces_dir}/interface-up-script-${interface}":
-  #     ensure  => present,
-  #     owner   => 'root',
-  #     mode    => '0755',
-  #     recurse => true,
-  #     content => template("l23network/ipconfig_${::osfamily}_ifup-script.erb"),
-  #   } ->
-  #   file {"${::l23network::params::interfaces_dir}/interface-dn-script-${interface}":
-  #     ensure  => present,
-  #     owner   => 'root',
-  #     mode    => '0755',
-  #     recurse => true,
-  #     content => template("l23network/ipconfig_${::osfamily}_ifdn-script.erb"),
-  #   } ->
-  #   File <| title == $interface_file |>
-  # }
-
   if ! defined (L3_ifconfig[$interface]) {
     if $provider {
       $config_provider = "${provider}_${::l23_os}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,8 @@
 class l23network::params {
   $monolith_bond_providers = ['ovs']
 
-  case $::osfamily {
-    /(?i)debian/: {
+  case $::l23_os {
+    /(?i)ubuntu/: {
       $interfaces_dir            = '/etc/network/interfaces.d'
       $interfaces_file           = '/etc/network/interfaces'
       $ovs_service_name          = 'openvswitch-switch'
@@ -18,12 +18,12 @@ class l23network::params {
       $ovs_kern_module_name      = 'openvswitch'
       $extra_tools               = 'iputils-arping'
     }
-    /(?i)redhat/: {
+    /(?i:redhat|centos)/: {
       $interfaces_dir            = '/etc/sysconfig/network-scripts'
       $interfaces_file           = undef
       $ovs_service_name          = 'openvswitch'
       $ovs_status_cmd            = '/etc/init.d/openvswitch status'
-      $lnx_vlan_tools            = 'vconfig'
+      $lnx_vlan_tools            = undef
       $lnx_bond_tools            = undef
       $lnx_ethernet_tools        = 'ethtool'
       $lnx_bridge_tools          = 'bridge-utils'
@@ -45,7 +45,7 @@ class l23network::params {
       $ovs_kern_module_name      = unedf
     }
     default: {
-      fail("Unsupported OS: ${::osfamily}/${::operatingsystem}")
+      fail("Unsupported OS: ${::l23_os}/${::operatingsystem}")
     }
   }
 }

--- a/spec/classes/l23network_init__spec.rb
+++ b/spec/classes/l23network_init__spec.rb
@@ -86,6 +86,7 @@ describe 'l23network', :type => :class do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
     } }
 
     let(:params) { {

--- a/spec/defines/ifconfig__dhcp__spec.rb
+++ b/spec/defines/ifconfig__dhcp__spec.rb
@@ -6,6 +6,7 @@ describe 'l23network::l3::ifconfig', :type => :define do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
       :kernel => 'Linux'
     } }
 

--- a/spec/defines/ifconfig__spec.rb
+++ b/spec/defines/ifconfig__spec.rb
@@ -6,6 +6,7 @@ describe 'l23network::l3::ifconfig', :type => :define do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
       :kernel => 'Linux'
     } }
 
@@ -55,6 +56,7 @@ describe 'l23network::l3::ifconfig', :type => :define do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
       :kernel => 'Linux'
     } }
 
@@ -103,6 +105,7 @@ describe 'l23network::l3::ifconfig', :type => :define do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
       :kernel => 'Linux'
     } }
 
@@ -152,6 +155,7 @@ describe 'l23network::l3::ifconfig', :type => :define do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
       :kernel => 'Linux'
     } }
 
@@ -200,6 +204,7 @@ describe 'l23network::l3::ifconfig', :type => :define do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
       :kernel => 'Linux'
     } }
 
@@ -230,6 +235,7 @@ describe 'l23network::l3::ifconfig', :type => :define do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
+      :l23_os => 'ubuntu',
       :kernel => 'Linux'
     } }
 

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth0
@@ -1,0 +1,5 @@
+# Advanced Micro Devices [AMD] 79c970 [PCnet32 LANCE]
+DEVICE=eth0
+BOOTPROTO=dhcp
+HWADDR=00:50:56:B2:00:1B
+ONBOOT=yes

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bridges_and_ports__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bridges_and_ports__spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
+
+  let(:input_data) do
+    {
+      :eth1 => {
+                 :name     => "eth1",
+                 :method   => "static",
+                 :ipaddr   => "169.254.0.1/24",
+                 :provider => "lnx_centos7",
+               },
+      :eth2 => {
+                 :name           => "eth2",
+                 :onboot         => "yes",
+                 :method         => "static",
+                 :ipaddr         => "192.168.22.3/24",
+                 :gateway        => "192.168.22.1",
+                 :gateway_metric => "231",
+                 :provider       => "lnx_centos7",
+               },
+      :'br-storage' => {
+                 :name     => "br-storage",
+                 :onboot   => "yes",
+                 :method   => "static",
+                 :ipaddr   => "192.168.55.33/24",
+                 :provider => "lnx_centos7",
+                 :routes   => { '10.109.22.0/24' => { 'gateway' => '192.168.55.54', 'destination' => '10.109.22.0/24' } }
+               }
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'lnx_centos7_spec')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "the method property" do
+    context 'when dhcp' do
+      let(:data) { subject.class.parse_file('eth0', fixture_data('ifcfg-eth0'))[0] }
+      it { expect(data[:method]).to eq :dhcp }
+    end
+  end
+
+  context "when formatting resources" do
+
+    context 'with test interface eth1' do
+      subject { providers[:eth1] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      it { expect(data).to match %r(DEVICE=eth1) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=169\.254\.0\.1) }
+      it { expect(data).not_to match %r(GATEWAY=.*) }
+      it { expect(data).not_to match %r(METRIC=.*) }
+      it { expect(data).to match %r(PREFIX=24) }
+
+      it 'should not remove GATEWAY from /etc/sysconfig/network' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+      it 'should not write route to /etc/sysconfig/network-scripts/route-eth1' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+    end
+
+    context 'with test interface eth2 with default gateway' do
+      subject { providers[:eth2] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      let(:content) { "NETWORKING=yes\nGATEWAY=5.5.5.5\n" }
+      let(:file) { '/etc/sysconfig/network' }
+
+      before(:each) do
+        puppet_debug_override()
+        subject.class.stubs(:read_file).with(file).returns content
+        subject.class.stubs(:write_file).returns true
+      end
+
+      it { expect(data).to match %r(DEVICE=eth2) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=192\.168\.22\.3) }
+      it { expect(data).to match %r(GATEWAY=192\.168\.22\.1) }
+      it { expect(data).to match %r(METRIC=231) }
+      it { expect(data).to match %r(PREFIX=24) }
+
+      it 'should remove GATEWAY from /etc/sysconfig/network' do
+        subject.class.expects(:write_file).with(file, "NETWORKING=yes\n").returns true
+        data
+      end
+      it 'should not write route to /etc/sysconfig/network-scripts/route-eth2' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+    end
+
+    context 'with test interface br-storage with routes' do
+      subject { providers[:'br-storage'] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      let(:content) { "10.109.22.0/24 via 192.168.55.54 dev br-storage\n" }
+      let(:file) { '/etc/sysconfig/network-scripts/route-br-storage' }
+
+      before(:each) do
+        puppet_debug_override()
+        subject.class.stubs(:write_file).returns true
+      end
+
+      it { expect(data).to match %r(DEVICE=br-storage) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=192\.168\.55\.33) }
+      it { expect(data).to match %r(PREFIX=24) }
+      it { expect(data).not_to match %r(ROUTES=.*) }
+
+      it 'should write route to /etc/sysconfig/network-scripts/route-br-storage' do
+        subject.class.expects(:write_file).with(file, content).returns true
+        data
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_redhat7__bridges_and_ports__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_redhat7__bridges_and_ports__spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:lnx_redhat7) do
+
+  let(:input_data) do
+    {
+      :eth1 => {
+                 :name     => "eth1",
+                 :method   => "static",
+                 :ipaddr   => "169.254.0.1/24",
+                 :provider => "lnx_redhat7",
+               },
+      :eth2 => {
+                 :name           => "eth2",
+                 :onboot         => "yes",
+                 :method         => "static",
+                 :ipaddr         => "192.168.22.3/24",
+                 :gateway        => "192.168.22.1",
+                 :gateway_metric => "231",
+                 :provider       => "lnx_redhat7",
+               },
+      :'br-storage' => {
+                 :name     => "br-storage",
+                 :onboot   => "yes",
+                 :method   => "static",
+                 :ipaddr   => "192.168.55.33/24",
+                 :provider => "lnx_redhat7",
+                 :routes   => { '10.109.22.0/24' => { 'gateway' => '192.168.55.54', 'destination' => '10.109.22.0/24' } }
+               }
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'lnx_centos7_spec')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "the method property" do
+    context 'when dhcp' do
+      let(:data) { subject.class.parse_file('eth0', fixture_data('ifcfg-eth0'))[0] }
+      it { expect(data[:method]).to eq :dhcp }
+    end
+  end
+
+  context "when formatting resources" do
+
+    context 'with test interface eth1' do
+      subject { providers[:eth1] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      it { expect(data).to match %r(DEVICE=eth1) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=169\.254\.0\.1) }
+      it { expect(data).not_to match %r(GATEWAY=.*) }
+      it { expect(data).not_to match %r(METRIC=.*) }
+      it { expect(data).to match %r(PREFIX=24) }
+
+      it 'should not remove GATEWAY from /etc/sysconfig/network' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+      it 'should not write route to /etc/sysconfig/network-scripts/route-eth1' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+    end
+
+    context 'with test interface eth2 with default gateway' do
+      subject { providers[:eth2] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      let(:content) { "NETWORKING=yes\nGATEWAY=5.5.5.5\n" }
+      let(:file) { '/etc/sysconfig/network' }
+
+      before(:each) do
+        puppet_debug_override()
+        subject.class.stubs(:read_file).with(file).returns content
+        subject.class.stubs(:write_file).returns true
+      end
+
+      it { expect(data).to match %r(DEVICE=eth2) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=192\.168\.22\.3) }
+      it { expect(data).to match %r(GATEWAY=192\.168\.22\.1) }
+      it { expect(data).to match %r(METRIC=231) }
+      it { expect(data).to match %r(PREFIX=24) }
+
+      it 'should remove GATEWAY from /etc/sysconfig/network' do
+        subject.class.expects(:write_file).with(file, "NETWORKING=yes\n").returns true
+        data
+      end
+      it 'should not write route to /etc/sysconfig/network-scripts/route-eth2' do
+        subject.class.expects(:write_file).times(0)
+        data
+      end
+    end
+
+    context 'with test interface br-storage with routes' do
+      subject { providers[:'br-storage'] }
+      let(:data) { subject.class.format_file('filepath', [subject]) }
+      let(:content) { "10.109.22.0/24 via 192.168.55.54 dev br-storage\n" }
+      let(:file) { '/etc/sysconfig/network-scripts/route-br-storage' }
+
+      before(:each) do
+        puppet_debug_override()
+        subject.class.stubs(:write_file).returns true
+      end
+
+      it { expect(data).to match %r(DEVICE=br-storage) }
+      it { expect(data).to match %r(ONBOOT=yes) }
+      it { expect(data).to match %r(BOOTPROTO=none) }
+      it { expect(data).to match %r(IPADDR=192\.168\.55\.33) }
+      it { expect(data).to match %r(PREFIX=24) }
+      it { expect(data).not_to match %r(ROUTES=.*) }
+
+      it 'should write route to /etc/sysconfig/network-scripts/route-br-storage' do
+        subject.class.expects(:write_file).with(file, content).returns true
+        data
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
* Add CentOS6 and CentOS7 separation to l23_os fact.
* Use l23_os fact instead of osfamily.
* Add CentOS7/RedHat7 support to l23_stored_config resource.
* Remove *vconfig* package due to we do not use *vconfig* to configure vlan
 interfaces hence we do not need to install it. CentOS7/RedHat7 does not have this
 package anymore as well.

Author: Stanislav Makar <smakar@mirantis.com>
FUEL-Change-Id: Ia6cb9e4efc9465030fe0ed8c2e46922db1513a74

Closes: #173