### PR TITLE
Fix tests for l23network

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :development, :test do
   gem 'rake',                    :require => false
   gem 'pry',                     :require => false
   gem 'rspec', '~>3.3',          :require => false
-  gem 'rspec-puppet', '~>2.1.0', :require => false
+  gem 'rspec-puppet', '~>2.2.0', :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint', '~> 0.3.2'
 end

--- a/spec/functions/get_network_role_property__spec.rb
+++ b/spec/functions/get_network_role_property__spec.rb
@@ -90,8 +90,8 @@ describe Puppet::Parser::Functions.function(:get_network_role_property) do
     it 'should return NIL for "admin" network role' do
       should run.with_params('admin', 'ipaddr_netmask_pair').and_return(nil)
     end
-    it 'should return NIL for "admin" network role' do
-      should run.with_params('admin', 'phys_dev').and_return(nil)
+    it 'should return eth0 for "admin" network role phys_dev' do
+      should run.with_params('admin', 'phys_dev').and_return(["eth0"])
     end
   end
 

--- a/spec/functions/get_transformation_property__spec.rb
+++ b/spec/functions/get_transformation_property__spec.rb
@@ -116,8 +116,12 @@ end
       should run.with_params('mtu', 'eth0').and_return(2048)
     end
 
-    it 'should return NIL for "eth2" transformation' do
-      should run.with_params('mtu', 'eth2').and_return(nil)
+    it 'should return 1024 for "eth2" transformation' do
+      should run.with_params('mtu', 'eth2').and_return(1024)
+    end
+
+    it 'should return NIL for "eth3" transformation' do
+      should run.with_params('mtu', 'eth3').and_return(nil)
     end
 
   end


### PR DESCRIPTION
This change includes an update to rspec-puppet ~> 2.2 and adjusting the
two tests that fail under 2.2 but not 2.1. I believe these failures are
related to https://github.com/rodjek/rspec-puppet/issues/266

The get_network_role_properly was previously passing because the return
value was not be properly check. In the code we are returning eth0 as
the interface for the admin network role and not nil.

The get_transformation_property was previously passing because the
return value was not correctly checked. Based on the code, the value for
eth2 should have been 1024 while the value for eth3 would have been nil.
This change updates the eth2 check with 1024 and adds a test case for
eth3.

FUEL-Change-Id: I7b87d02d4c702dde68ecd7f4abcd304e686fa795
FUEL-Closes-Bug: #1509056

Close: #182