### PR TITLE
Improve bond configuration saving for CentOS7/RHEL7

### DIFF
--- a/lib/puppet/provider/l23_stored_config_ovs_centos.rb
+++ b/lib/puppet/provider/l23_stored_config_ovs_centos.rb
@@ -5,8 +5,19 @@ class Puppet::Provider::L23_stored_config_ovs_centos < Puppet::Provider::L23_sto
   def self.property_mappings
     rv = super
     rv.merge!({
-      :devicetype => 'DEVICETYPE',
+      :devicetype     => 'DEVICETYPE',
+      :bridge         => 'OVS_BRIDGE',
+      :bond_slaves    => 'BOND_IFACES',
+      :bonding_opts   => 'OVS_OPTIONS',
+      :bond_mode      => 'bond_mode',
+      :bond_miimon    => 'other_config:bond-miimon-interval',
+      :bond_lacp      => 'lacp',
+      :bond_lacp_rate => 'other_config:lacp-time',
+      :bond_updelay   => 'bond_updelay',
+      :bond_downdelay => 'bond_downdelay',
     })
+    #delete non-OVS params
+    [:bond_ad_select, :bond_xmit_hash_policy, :bond_master].each { |p| rv.delete(p) }
     return rv
   end
 
@@ -26,21 +37,52 @@ class Puppet::Provider::L23_stored_config_ovs_centos < Puppet::Provider::L23_sto
     end
   end
 
-  def self.unmangle__if_type(provider, val)
-    if val == :bridge
-      val = :OVSBridge
-    else
-      val.to_s.capitalize.intern
+  def self.format_bond_opts(props)
+    props[:devicetype] = 'ovs'
+    bond_options = []
+    bond_properties = property_mappings.select { |k, v|  k.to_s =~ %r{bond_.*} and !([:bond_slaves].include?(k)) }
+    bond_properties.each do |param, transform |
+      if props.has_key?(param)
+        bond_options << "#{transform}=#{props[param]}"
+        props.delete(param)
+      end
     end
+    props[:bonding_opts]  = "\"#{bond_options.join(' ')}\""
+    props
+  end
+
+  def self.parse_bond_opts(hash)
+    pair_regex = %r/^\s*(.+?)\s*=\s*(.*)\s*$/
+    if hash.has_key?('OVS_OPTIONS')
+      bonding_opts_line = hash['OVS_OPTIONS'].gsub('"', '').split(' ')
+      bonding_opts_line.each do | bond_opt |
+        if (bom = bond_opt.match(pair_regex))
+          hash[bom[1].strip] = bom[2].strip
+        else
+          raise Puppet::Error, %{#{filename} is malformed; "#{line}" did not match "#{pair_regex.to_s}"}
+        end
+      end
+    hash.delete('OVS_OPTIONS')
+    end
+    hash
+  end
+
+  def self.unmangle__if_type(provider, val)
+    "OVS#{val.to_s.capitalize}".to_sym
   end
 
   def self.mangle__if_type(val)
-    if val == :OVSBridge
-      val = :bridge
-    else
-      val.to_s.downcase.intern
-    end
+    val.gsub('OVS', '').downcase.to_sym
   end
+
+  def self.unmangle__bond_slaves(provider, val)
+    "\"#{val.join(' ')}\""
+  end
+
+  def self.mangle__bond_slaves(val)
+    val.split(' ')
+  end
+
 
   #Dirty hack which deletes OVS bridges from patch OVS
   #interfaces
@@ -50,6 +92,7 @@ class Puppet::Provider::L23_stored_config_ovs_centos < Puppet::Provider::L23_sto
       val.delete('br-floating') if val.include?('br-floating')
       val
     end
+    val.join()
   end
 
 end

--- a/lib/puppet/type/l3_clear_route.rb
+++ b/lib/puppet/type/l3_clear_route.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:l3_clear_route) do
     newproperty(:interface) do
       desc "interface of the route"
       validate do |val|
-        if not val =~ /^[a-z_][\w\.\-]*[0-9a-z]$/
+        if not val.to_s =~ /^[a-z_][\w\.\-]*[0-9a-z]$/
           fail("Invalid interface name: '#{val}'")
         end
       end

--- a/manifests/l2/bond.pp
+++ b/manifests/l2/bond.pp
@@ -27,7 +27,7 @@ define l23network::l2::bond (
   $onboot                  = undef,
   $delay_while_up          = undef,
 # $ethtool                 = undef,
-  $bond_properties         = undef,  # bond configuration options
+  $bond_properties         = {},  # bond configuration options
   $interface_properties    = undef,  # configuration options for included interfaces (mtu, ethtool, etc...)
   $vendor_specific         = undef,
   $monolith_bond_providers = undef,

--- a/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-lnx-bond1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-lnx-bond1
@@ -1,0 +1,7 @@
+BOOTPROTO=none
+DEVICE=lnx_bond1
+ONBOOT=yes
+MTU=9000
+TYPE=Bond
+BRIDGE=lnx-br0
+BONDING_OPTS="mode=balance-tcp miimon=60 lacp_rate=fast ad_select=2 updelay=123 downdelay=155"

--- a/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-ovs-bondlacp1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-ovs-bondlacp1
@@ -1,0 +1,9 @@
+BOOTPROTO=none
+DEVICE=ovs_bond_lacp
+ONBOOT=yes
+MTU=9000
+TYPE=OVSBond
+OVS_BRIDGE=br0
+OVS_OPTIONS="bond_mode=balance-tcp other_config:bond-miimon-interval=50 lacp=active other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222"
+DEVICETYPE=ovs
+BOND_IFACES="eth2 eth3"

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bond__spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+require 'yaml'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
+
+  let(:facts) do
+    {
+      :osfamily => 'Redhat',
+      :operatingsystem => 'CentOS',
+      :l23_os => 'centos7',
+    }
+  end
+
+  let(:input_data) do
+    {
+      :lnx_bond1 => {
+        :name           => 'lnx-bond1',
+        :ensure         => 'present',
+        :if_type        => 'bond',
+        :bridge         => 'lnx-br0',
+        :mtu            => '9000',
+        :onboot         => true,
+        :method         => 'manual',
+        :bond_mode      => 'balance-tcp',
+        :bond_slaves    => ['eth2', 'eth3'],
+        :bond_miimon    => '60',
+        :bond_lacp_rate => 'fast',
+        :bond_lacp      => 'active',
+        :bond_updelay   => '123',
+        :bond_downdelay => '155',
+        :bond_ad_select => '2',   # unused for OVS
+        :provider       => "lnx_centos7",
+      },
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    return resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'centos7_bonds')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "LNX bond" do
+
+    context 'format file' do
+      subject { providers[:lnx_bond1] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=lnx-bond1}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{TYPE=Bond}) }
+      it { expect(cfg_file).to match(%r{BRIDGE=lnx-br0}) }
+      it { expect(cfg_file).to match(%r{MTU=9000}) }
+      it { expect(cfg_file).to match(%r{BONDING_OPTS="mode=balance-tcp miimon=60 lacp_rate=fast ad_select=2 updelay=123 downdelay=155"}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+
+    end
+
+    context "parse data from fixture" do
+      let(:res) { subject.class.parse_file('lnx-bond1', fixture_data('ifcfg-lnx-bond1'))[0] }
+
+      it { expect(res[:mtu]).to eq '9000' }
+      it { expect(res[:bridge]).to eq ['lnx-br0'] }
+      it { expect(res[:if_type].to_s).to eq 'bond' }
+      it { expect(res[:bond_mode]).to eq 'balance-tcp' }
+      it { expect(res[:bond_miimon]).to eq '60' }
+      it { expect(res[:bond_lacp_rate]).to eq 'fast' }
+      it { expect(res[:bond_lacp]).not_to eq 'active' }
+      it { expect(res[:bond_updelay]).to eq '123' }
+      it { expect(res[:bond_downdelay]).to eq '155' }
+    end
+
+  end
+
+end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bond__spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+require 'yaml'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
+
+  let(:facts) do
+    {
+      :osfamily => 'Redhat',
+      :operatingsystem => 'CentOS',
+      :l23_os => 'centos7',
+    }
+  end
+
+  let(:input_data) do
+    {
+      :ovs_bondlacp1 => {
+        :name           => 'ovs-bondlacp1',
+        :ensure         => 'present',
+        :if_type        => 'bond',
+        :bridge         => 'br0',
+        :mtu            => '9000',
+        :onboot         => true,
+        :method         => 'manual',
+        :bond_mode      => 'balance-tcp',
+        :bond_slaves    => ['eth2', 'eth3'],
+        :bond_miimon    => '50',
+        :bond_lacp_rate => 'fast',
+        :bond_lacp      => 'active',
+        :bond_updelay   => '111',
+        :bond_downdelay => '222',
+        :bond_ad_select => '2',   # unused for OVS
+        :provider       => "ovs_centos7",
+      },
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    return resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'centos7_bonds')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "OVS bond with two interfaces" do
+
+    context 'format file' do
+      subject { providers[:ovs_bondlacp1] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=ovs-bondlacp1}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{TYPE=OVSBond}) }
+      it { expect(cfg_file).to match(%r{OVS_BRIDGE=br0}) }
+      it { expect(cfg_file).to match(%r{MTU=9000}) }
+      it { expect(cfg_file).to match(%r{OVS_OPTIONS="bond_mode=balance-tcp other_config:bond-miimon-interval=50 \
+other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222 lacp=active"}) }
+      it { expect(cfg_file).to match(%r{BOND_IFACES="eth2 eth3"}) }
+      it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(9) }  #  no more lines in the interface file
+
+    end
+
+    context "parse data from fixture" do
+      let(:res) { subject.class.parse_file('ovs-bondlacp1', fixture_data('ifcfg-ovs-bondlacp1'))[0] }
+      it { expect(res[:mtu]).to eq '9000' }
+      it { expect(res[:bridge]).to eq ['br0'] }
+      it { expect(res[:if_type].to_s).to eq 'bond' }
+      it { expect(res[:bond_mode]).to eq 'balance-tcp' }
+      it { expect(res[:bond_miimon]).to eq '50' }
+      it { expect(res[:bond_lacp_rate]).to eq 'fast' }
+      it { expect(res[:bond_lacp]).to eq 'active' }
+      it { expect(res[:bond_updelay]).to eq '111' }
+      it { expect(res[:bond_downdelay]).to eq '222' }
+      it { expect(res[:bond_slaves]).to eq ['eth2', 'eth3'] }
+    end
+
+  end
+
+end


### PR DESCRIPTION
*Add support of OVS bond configuration saving
*Implement such bond parameters as ad_select, updelay and downdelay for lnx
provider
*Refactor formating and parsing bond options
*Test coverage

FUEL-Change-Id: I7cf1311f82c6aee980cb5d338ee7f2c0504418d6

Close: #184