### PR TITLE
Refactor function configure_default_route

### DIFF
--- a/lib/puppet/provider/l23_stored_config/ovs_centos6.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_centos6.rb
@@ -6,7 +6,6 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_centos6, :parent => Puppet::P
   include PuppetX::FileMapper
 
   confine    :l23_os => :centos6
-  defaultfor :l23_os => :centos6
 
   has_feature :provider_options
 

--- a/lib/puppet/provider/l23_stored_config/ovs_centos7.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_centos7.rb
@@ -6,7 +6,6 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_centos7, :parent => Puppet::P
   include PuppetX::FileMapper
 
   confine    :l23_os => :centos7
-  defaultfor :l23_os => :centos7
 
   has_feature :provider_options
 

--- a/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
@@ -6,7 +6,6 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
   include PuppetX::FileMapper
 
   confine    :l23_os => :ubuntu
-  defaultfor :l23_os => :ubuntu
 
   has_feature :provider_options
 

--- a/lib/puppet/type/l23_stored_config.rb
+++ b/lib/puppet/type/l23_stored_config.rb
@@ -365,7 +365,7 @@ Puppet::Type.newtype(:l23_stored_config) do
 
   def generate
     # if_type = :ethernet is the same as if_type = nil
-    if (!([:absent, :none, :nil, :undef] & self[:bridge]).any? and ([:ethernet, :bond].include? self[:if_type] or self[:if_type].nil?))
+    if (!([:absent, :none, :nil, :undef] & self[:bridge]).any? and ([:ethernet, :bond, :vport, :patch].include? self[:if_type] or self[:if_type].nil?))
       self[:bridge].each do |bridge|
         br = self.catalog.resource('L23_stored_config', bridge)
         fail("Stored_config resource for bridge '#{bridge}' not found for port '#{self[:name]}'!") if ! br


### PR DESCRIPTION
Before the function configure_default_route was a little part of function
generate_network_config which changed default gateway only, due to the provider
for interfaces was not picked correctly.
Now if default route is needed to change we just modify network_scheme
and call generate_network_config with this network_scheme, if no - do
nothing.
Leave only provider lnx as default for l23_stored_config.

FUEL-Change-Id: I33e88550af5d5cce2886254444ee5d450e578a1c
FUEL-Closes-bug: #1510072

Closes: #194