### PR TITLE
Implement Ovs2Ovs patch support CentOS7/RHEL7

### DIFF
--- a/lib/puppet/provider/l2_port/ovs.rb
+++ b/lib/puppet/provider/l2_port/ovs.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:l2_port).provide(:ovs, :parent => Puppet::Provider::Ovs_base)
     @old_property_hash = {}
     @property_flush = {}.merge! @resource
     #
-    cmd = ["add-port", @resource[:bridge], @resource[:interface]]
+    cmd = ['--may-exist', 'add-port', @resource[:bridge], @resource[:interface]]
     # # tag and trunks for port
     # port_properties = @resource[:port_properties]
     # if ![nil, :absent].include? @resource[:vlan_id] and @resource[:vlan_id] > 0

--- a/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch1
@@ -1,0 +1,7 @@
+BOOTPROTO=none
+DEVICE=ovs2ovs-patch1
+ONBOOT=yes
+TYPE=OVSPatchPort
+OVS_BRIDGE=ovs-br1
+OVS_PATCH_PEER=ovs2ovs-patch2
+DEVICETYPE=ovs

--- a/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch2
+++ b/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch2
@@ -1,0 +1,7 @@
+BOOTPROTO=none
+DEVICE=ovs2ovs-patch2
+ONBOOT=yes
+TYPE=OVSPatchPort
+OVS_BRIDGE=ovs-br2
+OVS_PATCH_PEER=ovs2ovs-patch1
+DEVICETYPE=ovs

--- a/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-tag
+++ b/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-tag
@@ -1,0 +1,8 @@
+BOOTPROTO=none
+DEVICE=ovs2ovs-tag
+ONBOOT=yes
+OVS_OPTIONS="tag=3"
+TYPE=OVSPatchPort
+OVS_BRIDGE=ovs-brt2
+OVS_PATCH_PEER=ovs2ovs-patcht1
+DEVICETYPE=ovs

--- a/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port
+++ b/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port
@@ -1,0 +1,5 @@
+BOOTPROTO=none
+DEVICE=lnx-port
+ONBOOT=yes
+MTU=9000
+TYPE=Ethernet

--- a/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port2
+++ b/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port2
@@ -1,0 +1,4 @@
+BOOTPROTO=none
+DEVICE=lnx-port2
+ONBOOT=yes
+MTU=9000

--- a/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-ovs-port
+++ b/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-ovs-port
@@ -1,0 +1,6 @@
+BOOTPROTO=none
+DEVICE=ovs-port
+ONBOOT=yes
+MTU=9000
+TYPE=OVSPort
+DEVICETYPE=ovs

--- a/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p1
+++ b/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p1
@@ -1,0 +1,5 @@
+allow-br-ovs1 p2p1
+iface p2p1 inet manual
+ovs_type OVSPort
+ovs_bridge br-ovs1
+ovs_extra -- set Port p2p1 tag=100

--- a/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p2
+++ b/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p2
@@ -1,0 +1,2 @@
+auto p2p2
+iface p2p2 inet manual

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__port__spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+require 'yaml'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
+
+  let(:facts) do
+    {
+      :osfamily => 'Redhat',
+      :operatingsystem => 'CentOS',
+      :l23_os => 'centos7',
+    }
+  end
+
+  let(:input_data) do
+    {
+      :lnx_port => {
+        :name           => 'lnx-port',
+        :ensure         => 'present',
+        :if_type        => 'ethernet',
+        :mtu            => '9000',
+        :onboot         => true,
+        :method         => 'manual',
+        :provider       => 'lnx_centos7',
+      },
+      :lnx_port_without_type => {
+        :name           => 'lnx-port2',
+        :ensure         => 'present',
+        :mtu            => '9000',
+        :onboot         => true,
+        :method         => 'manual',
+        :provider       => 'lnx_centos7',
+      },
+
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'centos7_ports')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "lnx port" do
+
+    context 'format file for lnx-port' do
+      subject { providers[:lnx_port] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=lnx-port}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{TYPE=Ethernet}) }
+      it { expect(cfg_file).to match(%r{MTU=9000}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }  #  no more lines in the interface file
+    end
+
+    context 'format file for lnx-port2 without type' do
+      subject { providers[:lnx_port_without_type] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=lnx-port2}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{MTU=9000}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }  #  no more lines in the interface file
+    end
+
+
+    context "parse port lnx-port data from fixture" do
+      let(:res) { subject.class.parse_file('lnx-port', fixture_data('ifcfg-lnx-port'))[0] }
+      it { expect(res[:name]).to eq 'lnx-port' }
+      it { expect(res[:if_type].to_s).to eq 'ethernet' }
+      it { expect(res[:method].to_s).to eq 'manual' }
+      it { expect(res[:mtu]).to eq '9000' }
+      it { expect(res[:onboot]).to eq true }
+      it { expect(res[:provider]).to eq :lnx_centos7 }
+    end
+
+    context "parse port lnx-port2 data from fixture" do
+      let(:res) { subject.class.parse_file('lnx-port2', fixture_data('ifcfg-lnx-port2'))[0] }
+      it { expect(res[:name]).to eq 'lnx-port2' }
+      it { expect(res[:method].to_s).to eq 'manual' }
+      it { expect(res[:mtu]).to eq '9000' }
+      it { expect(res[:onboot]).to eq true }
+      it { expect(res[:provider]).to eq :lnx_centos7 }
+    end
+
+  end
+
+end

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__port__spec.rb
@@ -1,16 +1,14 @@
 require 'spec_helper'
 
 resources_map =     {
-      :'p2p1' => {
-                 :name     => 'p2p1',
+      :'p2p2' => {
+                 :name     => 'p2p2',
                  :if_type  => 'ethernet',
-                 :bridge   => 'br-ovs1',
-                 :vlan_id  => '100',
-                 :provider => 'ovs_ubuntu',
+                 :provider => 'lnx_ubuntu',
                },
 }
 
-describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
+describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
 
   let(:input_data) { resources_map}
 
@@ -57,28 +55,24 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
 
   context "formating config files" do
 
-    context 'OVS port p2p1 ' do
-      subject { providers[:'p2p1'] }
+    context 'OVS port p2p2 ' do
+      subject { providers[:'p2p2'] }
       let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
-      it { expect(cfg_file).to match(/allow-br-ovs1\s+p2p1/) }
-      it { expect(cfg_file).to match(/iface\s+p2p1\s+inet\s+manual/) }
-      it { expect(cfg_file).to match(/ovs_type\s+OVSPort/) }
-      it { expect(cfg_file).to match(/ovs_bridge\s+br-ovs1/) }
-      it { expect(cfg_file).to match(/ovs_extra\s+--\s+set\s+Port\s+p2p1\st+ag=100/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }
+      it { expect(cfg_file).to match(/auto\s+p2p2/) }
+      it { expect(cfg_file).to match(/iface\s+p2p2\s+inet\s+manual/) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(2) }
     end
 
   end
 
   context "parsing config files" do
 
-    context 'OVS port p2p1' do
-      let(:res) { subject.class.parse_file('p2p1', fixture_data('ifcfg-p2p1'))[0] }
+    context 'OVS port p2p2' do
+      let(:res) { subject.class.parse_file('p2p2', fixture_data('ifcfg-p2p2'))[0] }
       it { expect(res[:method]).to eq :manual }
-      it { expect(res[:name]).to eq 'p2p1' }
-      it { expect(res[:bridge]).to eq "br-ovs1" }
-      it { expect(res[:vlan_id]).to eq '100' }
-      it { expect(res[:if_provider].to_s).to eq 'ovs' }
+      it { expect(res[:onboot]).to eq true }
+      it { expect(res[:name]).to eq 'p2p2' }
+      it { expect(res[:if_provider].to_s).to eq 'lnx' }
     end
 
   end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__ovs2ovs_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__ovs2ovs_patch__spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+require 'yaml'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
+
+  let(:facts) do
+    {
+      :osfamily => 'Redhat',
+      :operatingsystem => 'CentOS',
+      :l23_os => 'centos7',
+    }
+  end
+
+  let(:input_data) do
+    {
+      :ovs2ovs_patch1 => {
+        :name           => 'ovs2ovs-patch1',
+        :ensure         => 'present',
+        :if_type        => 'patch',
+        :bridge         => ['ovs-br1'],
+        :jacks          => ['ovs2ovs-patch2'],
+        :onboot         => true,
+        :method         => 'manual',
+        :provider       => 'ovs_centos7',
+      },
+      :ovs2ovs_patch2 => {
+        :name           => 'ovs2ovs-patch2',
+        :ensure         => 'present',
+        :if_type        => 'patch',
+        :bridge         => ['ovs-br2'],
+        :jacks          => ['ovs2ovs-patch1'],
+        :onboot         => true,
+        :method         => 'manual',
+        :provider       => 'ovs_centos7',
+      },
+      :ovs2ovs_patch_with_tag => {
+        :name           => 'ovs2ovs-tag',
+        :ensure         => 'present',
+        :if_type        => 'patch',
+        :bridge         => ['ovs-brt2'],
+        :jacks          => ['ovs2ovs-patcht1'],
+        :vlan_id        => 3,
+        :onboot         => true,
+        :method         => 'manual',
+        :provider       => 'ovs_centos7',
+      },
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    return resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'centos7_patches')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "ovs2ovs patch" do
+
+    context 'format ovs2ovs-patch2 file' do
+      subject { providers[:ovs2ovs_patch1] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=ovs2ovs-patch1}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{TYPE=OVSPatchPort}) }
+      it { expect(cfg_file).to match(%r{OVS_BRIDGE=ovs-br1}) }
+      it { expect(cfg_file).to match(%r{OVS_PATCH_PEER=ovs2ovs-patch2}) }
+      it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+    end
+
+    context 'format ovs2ovs-patch2 file' do
+      subject { providers[:ovs2ovs_patch2] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=ovs2ovs-patch2}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{TYPE=OVSPatchPort}) }
+      it { expect(cfg_file).to match(%r{OVS_BRIDGE=ovs-br2}) }
+      it { expect(cfg_file).to match(%r{OVS_PATCH_PEER=ovs2ovs-patch1}) }
+      it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+    end
+
+    context 'format ovs2ovs-patch with tag file' do
+      subject { providers[:ovs2ovs_patch_with_tag] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=ovs2ovs-tag}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{TYPE=OVSPatchPort}) }
+      it { expect(cfg_file).to match(%r{OVS_BRIDGE=ovs-brt2}) }
+      it { expect(cfg_file).to match(%r{OVS_PATCH_PEER=ovs2ovs-patcht1}) }
+      it { expect(cfg_file).to match(%r{OVS_OPTIONS="tag=3"}) }
+      it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(8) }  #  no more lines in the interface file
+    end
+
+    context "parse ovs2ovs-patch1 data from fixture" do
+      let(:res) { subject.class.parse_file('ovs2ovs-patch1', fixture_data('ifcfg-ovs2ovs-patch1'))[0] }
+      it { expect(res[:name]).to eq 'ovs2ovs-patch1' }
+      it { expect(res[:if_type].to_s).to eq 'patch' }
+      it { expect(res[:bridge]).to match_array(['ovs-br1']) }
+      it { expect(res[:jacks]).to match_array(['ovs2ovs-patch2']) }
+      it { expect(res[:method].to_s).to eq 'manual' }
+      it { expect(res[:onboot]).to eq true }
+      it { expect(res[:provider].to_s).to eq 'ovs_centos7' }
+    end
+
+    context "parse ovs2ovs-patch2 data from fixture" do
+      let(:res) { subject.class.parse_file('ovs2ovs-patch2', fixture_data('ifcfg-ovs2ovs-patch2'))[0] }
+      it { expect(res[:name]).to eq 'ovs2ovs-patch2' }
+      it { expect(res[:if_type].to_s).to eq 'patch' }
+      it { expect(res[:bridge]).to match_array(['ovs-br2']) }
+      it { expect(res[:jacks]).to match_array(['ovs2ovs-patch1']) }
+      it { expect(res[:method].to_s).to eq 'manual' }
+      it { expect(res[:onboot]).to eq true }
+      it { expect(res[:provider].to_s).to eq 'ovs_centos7' }
+    end
+
+    context "parse ovs2ovs-tag data from fixture" do
+      let(:res) { subject.class.parse_file('ovs2ovs-tag', fixture_data('ifcfg-ovs2ovs-tag'))[0] }
+      it { expect(res[:name]).to eq 'ovs2ovs-tag' }
+      it { expect(res[:if_type].to_s).to eq 'patch' }
+      it { expect(res[:bridge]).to match_array(['ovs-brt2']) }
+      it { expect(res[:jacks]).to match_array(['ovs2ovs-patcht1']) }
+      it { expect(res[:vlan_id]).to eq('3') }
+      it { expect(res[:method].to_s).to eq 'manual' }
+      it { expect(res[:onboot]).to eq true }
+      it { expect(res[:provider].to_s).to eq 'ovs_centos7' }
+    end
+
+  end
+
+end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__port__spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+require 'yaml'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
+
+  let(:facts) do
+    {
+      :osfamily => 'Redhat',
+      :operatingsystem => 'CentOS',
+      :l23_os => 'centos7',
+    }
+  end
+
+  let(:input_data) do
+    {
+      :ovs_port => {
+        :name           => 'ovs-port',
+        :ensure         => 'present',
+        :if_type        => 'ethernet',
+        :mtu            => '9000',
+        :onboot         => true,
+        :method         => 'manual',
+        :provider       => 'ovs_centos7',
+      },
+    }
+  end
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    return resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'centos7_ports')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "OVS port" do
+
+    context 'format file for ovs-port' do
+      subject { providers[:ovs_port] }
+      let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
+      it { expect(cfg_file).to match(%r{DEVICE=ovs-port}) }
+      it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
+      it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
+      it { expect(cfg_file).to match(%r{TYPE=OVSPort}) }
+      it { expect(cfg_file).to match(%r{MTU=9000}) }
+      it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }  #  no more lines in the interface file
+
+    end
+
+    context "parse port ovs-port data from fixture" do
+      let(:res) { subject.class.parse_file('ovs-port', fixture_data('ifcfg-ovs-port'))[0] }
+      it { expect(res[:name]).to eq 'ovs-port' }
+      it { expect(res[:if_type].to_s).to eq 'ethernet' }
+      it { expect(res[:method].to_s).to eq 'manual' }
+      it { expect(res[:mtu]).to eq '9000' }
+      it { expect(res[:onboot]).to eq true }
+      it { expect(res[:provider]).to eq :ovs_centos7 }
+    end
+
+  end
+
+end


### PR DESCRIPTION
*Implement tags for ovs2ovs patch for Centos7/RHEL7
*Implement ovs port for Ubuntu and Centos7/RHEL7
*Test coverage

FUEL-Change-Id: I553a9d152f83b6a24ab5a5a3e4bb6bf41edbb303
FUEL-Closes-bug: #1514421

Closes: #198