### PR TITLE
Set default mtu value for l2 patch

### DIFF
--- a/manifests/l2/patch.pp
+++ b/manifests/l2/patch.pp
@@ -7,7 +7,7 @@
 #   Bridges that will be connected.
 #
 # [*mtu*]
-#   Specify MTU value for patchcord.
+#   Specify MTU value for patchcord. Default value is 65000
 #
 # [*vlan_ids*]
 #   Specify 802.1q tag for each end of patchcord. Must be array of 2 integers.
@@ -17,7 +17,7 @@ define l23network::l2::patch (
   $bridges,
   $use_ovs         = $::l23network::use_ovs,
   $ensure          = present,
-  $mtu             = undef,
+  $mtu             = 65000,
   $vlan_ids        = undef,
   $vendor_specific = undef,
   $provider        = undef,


### PR DESCRIPTION
We did not set mtu for ovs2lnx and lnx2lnx patches by default, but as it is
not HW it is better to have not fragmentation there at all.

FUEL-Change-Id: I2420b0122b7fe14c60146bf9b42f7f1bc409c2b7
FUEL-Related-bug: #1529098

Closes: #221