### PR TITLE
Add puppet header to interface config files

### DIFF
--- a/lib/puppet/provider/l23_stored_config/lnx_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/lnx_ubuntu.rb
@@ -26,6 +26,8 @@ Puppet::Type.type(:l23_stored_config).provide(:lnx_ubuntu, :parent => Puppet::Pr
   def self.iface_file_header(provider)
     rv = []
 
+    rv << self.puppet_header
+
     # Add onboot interfaces
     if provider.onboot
       rv << "auto #{provider.name}"

--- a/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
@@ -80,6 +80,7 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
     header = []
     props  = {}
 
+    header << self.puppet_header
     bridge = provider.bridge[0]
     if provider.if_type.to_s == 'bridge'
       header << "auto #{provider.name}" if provider.onboot

--- a/lib/puppet/provider/l23_stored_config_base.rb
+++ b/lib/puppet/provider/l23_stored_config_base.rb
@@ -62,5 +62,15 @@ class Puppet::Provider::L23_stored_config_base < Puppet::Provider
     File.chmod(0644, filename) if File.exist? filename
   end
 
+  def self.puppet_header
+    str = "# *********************************************************************\n"\
+          "# This file is being managed by Puppet. Changes to interfaces\n"\
+          "# that are not being managed by Puppet will persist;\n"\
+          "# however changes to interfaces that are being managed by Puppet will\n"\
+          "# be overwritten.\n"\
+          "# *********************************************************************"
+    str
+  end
+
 end
 # vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l23_stored_config_centos.rb
+++ b/lib/puppet/provider/l23_stored_config_centos.rb
@@ -292,6 +292,7 @@ class Puppet::Provider::L23_stored_config_centos < Puppet::Provider::L23_stored_
     end
 
     content = []
+    content << self.puppet_header
     provider = providers[0]
 
     # Map everything to a flat hash

--- a/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-lnx-bond1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-lnx-bond1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=lnx_bond1
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-ovs-bondlacp1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-ovs-bondlacp1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=ovs_bond_lacp
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_bridges/ifcfg-lnx-bridge
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bridges/ifcfg-lnx-bridge
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=lnx-bridge
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_bridges/ifcfg-ovs-bridge
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bridges/ifcfg-ovs-bridge
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=ovs-bridge
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2lnx-patch
+++ b/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2lnx-patch
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=ovs2lnx-patch
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=ovs2ovs-patch1
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch2
+++ b/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-patch2
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=ovs2ovs-patch2
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-tag
+++ b/spec/fixtures/provider/l23_stored_config/centos7_patches/ifcfg-ovs2ovs-tag
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=ovs2ovs-tag
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port
+++ b/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=lnx-port
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port2
+++ b/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port2
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=lnx-port2
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port3
+++ b/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-lnx-port3
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=lnx-port3
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-ovs-port
+++ b/spec/fixtures/provider/l23_stored_config/centos7_ports/ifcfg-ovs-port
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=ovs-port
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos6_spec/ifcfg-eth0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos6_spec/ifcfg-eth0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 # Advanced Micro Devices [AMD] 79c970 [PCnet32 LANCE]
 DEVICE=eth0
 BOOTPROTO=dhcp

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-br1
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-br1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 IPADDR=192.168.88.2
 DEVICE=br1

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-br2
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-br2
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 IPADDR=192.168.99.2
 DEVICE=br2

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-p_33470efd-0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-p_33470efd-0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=p_33470efd-0
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-p_33470efd-1
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/ifcfg-p_33470efd-1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=p_33470efd-1
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/pre-up-ifcfg-p_33470efd-0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/pre-up-ifcfg-p_33470efd-0
@@ -1,2 +1,8 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 ip link add p_33470efd-0 mtu 1500 type veth peer name p_33470efd-1 mtu 1500
 ip link set up dev p_33470efd-1

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/pre-up-ifcfg-p_33470efd-1
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec/pre-up-ifcfg-p_33470efd-1
@@ -1,2 +1,8 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 ip link add p_33470efd-0 mtu 1500 type veth peer name p_33470efd-1 mtu 1500
 ip link set up dev p_33470efd-1

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 # Advanced Micro Devices [AMD] 79c970 [PCnet32 LANCE]
 DEVICE=eth0
 BOOTPROTO=dhcp

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth31
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth31
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 # Advanced Micro Devices [AMD] 79c970 [PCnet32 LANCE]
 NAME=eth31
 BOOTPROTO=dhcp

--- a/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth32
+++ b/spec/fixtures/provider/l23_stored_config/lnx_centos7_spec/ifcfg-eth32
@@ -1,2 +1,8 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=dhcp
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-br1
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-br1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br1
 iface br1 inet static
   bridge_ports p_33470efd-0

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-br2
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-br2
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br2
 iface br2 inet static
   bridge_ports p_33470efd-1

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-p_33470efd-0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-p_33470efd-0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto p_33470efd-0
 iface p_33470efd-0 inet manual
   pre-up ip link add p_33470efd-0 mtu 1500 type veth peer name p_33470efd-1 mtu 1500

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-p_33470efd-1
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec/ifcfg-p_33470efd-1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto p_33470efd-1
 iface p_33470efd-1 inet manual
   pre-up ip link add p_33470efd-0 mtu 1500 type veth peer name p_33470efd-1 mtu 1500

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-bond0
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-bond0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto bond0
 iface bond0 inet manual
   mtu 9000

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-eth1
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-eth1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto eth1
 iface eth1 inet static
 address 169.254.0.1/24

--- a/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-eth11
+++ b/spec/fixtures/provider/l23_stored_config/lnx_ubuntu__spec/ifcfg-eth11
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto eth11
 iface eth11 inet static
 address 169.254.0.1/24

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec/ifcfg-br-ovs
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec/ifcfg-br-ovs
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br-ovs
 allow-ovs br-ovs
 iface br-ovs inet manual

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec/ifcfg-br1
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec/ifcfg-br1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br1
 iface br1 inet static
   bridge_ports p_33470efd-0

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec/ifcfg-p_33470efd-0
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec/ifcfg-p_33470efd-0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto p_33470efd-0
 allow-br-ovs p_33470efd-0
 iface p_33470efd-0 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-br-ovs1
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-br-ovs1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br-ovs1
 allow-ovs br-ovs1
 iface br-ovs1 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-br-ovs2
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-br-ovs2
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br-ovs2
 allow-ovs br-ovs2
 iface br-ovs2 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-p_33470efd-0
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-p_33470efd-0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto p_33470efd-0
 allow-br-ovs1 p_33470efd-0
 iface p_33470efd-0 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-p_33470efd-1
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec/ifcfg-p_33470efd-1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto p_33470efd-1
 allow-br-ovs2 p_33470efd-1
 iface p_33470efd-1 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bond_lacp
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bond_lacp
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 allow-br0 bond_lacp
 iface bond_lacp inet manual
   mtu 9000

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 allow-ovs br9
 iface br9 inet manual
   ovs_type OVSBridge

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge-with-ports
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge-with-ports
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br8
 allow-ovs br8
 iface br8 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-port
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-port
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto ttt0
 allow-br9 ttt0
 iface ttt0 inet manual

--- a/spec/fixtures/provider/l23_stored_config/prefetching/centos/ifcfg-br-testovs
+++ b/spec/fixtures/provider/l23_stored_config/prefetching/centos/ifcfg-br-testovs
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 DEVICE=br-testovs
 ONBOOT=yes

--- a/spec/fixtures/provider/l23_stored_config/prefetching/centos/ifcfg-eth0
+++ b/spec/fixtures/provider/l23_stored_config/prefetching/centos/ifcfg-eth0
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 # Advanced Micro Devices [AMD] 79c970 [PCnet32 LANCE]
 DEVICE=eth0
 BOOTPROTO=dhcp

--- a/spec/fixtures/provider/l23_stored_config/prefetching/centos/ifcfg-eth1.105
+++ b/spec/fixtures/provider/l23_stored_config/prefetching/centos/ifcfg-eth1.105
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 BOOTPROTO=none
 IPADDR=10.109.2.3
 DEVICE=eth1.105

--- a/spec/fixtures/provider/l23_stored_config/prefetching/ubuntu/ifcfg-br-floating
+++ b/spec/fixtures/provider/l23_stored_config/prefetching/ubuntu/ifcfg-br-floating
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br-floating
 allow-ovs br-floating
 iface br-floating inet manual

--- a/spec/fixtures/provider/l23_stored_config/prefetching/ubuntu/ifcfg-br-fw-admin
+++ b/spec/fixtures/provider/l23_stored_config/prefetching/ubuntu/ifcfg-br-fw-admin
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto br-fw-admin
 iface br-fw-admin inet static
 bridge_ports eth0 p_eeee51a2-0

--- a/spec/fixtures/provider/l23_stored_config/prefetching/ubuntu/ifcfg-eth1
+++ b/spec/fixtures/provider/l23_stored_config/prefetching/ubuntu/ifcfg-eth1
@@ -1,2 +1,8 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto eth1
 iface eth1 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p1
+++ b/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p1
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 allow-br-ovs1 p2p1
 iface p2p1 inet manual
 ovs_type OVSPort

--- a/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p2
+++ b/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p2
@@ -1,2 +1,8 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto p2p2
 iface p2p2 inet manual

--- a/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p3
+++ b/spec/fixtures/provider/l23_stored_config/ubuntu_ports/ifcfg-p2p3
@@ -1,3 +1,9 @@
+# *********************************************************************
+# This file is being managed by Puppet. Changes to interfaces
+# that are not being managed by Puppet will persist;
+# however changes to interfaces that are being managed by Puppet will
+# be overwritten.
+# *********************************************************************
 auto p2p3
 iface p2p3 inet manual
 post-up ethtool -K p2p3 gro off | true  # generic-receive-offload

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bond__spec.rb
@@ -87,7 +87,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(%r{BRIDGE=lnx-br0}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
       it { expect(cfg_file).to match(%r{BONDING_OPTS="mode=balance-tcp miimon=60 lacp_rate=fast ad_select=2 updelay=123 downdelay=155"}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bridge__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bridge__spec.rb
@@ -74,7 +74,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
       it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
       it { expect(cfg_file).to match(%r{TYPE=Bridge}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__lnx2lnx_patch__spec.rb
@@ -98,7 +98,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(/ONBOOT=yes/) }
       it { expect(cfg_file).to match(/TYPE=Bridge/) }
       it { expect(cfg_file).to match(/PREFIX=24/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }
     end
 
     context 'for LNX bridge br2' do
@@ -110,7 +110,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(/ONBOOT=yes/) }
       it { expect(cfg_file).to match(/TYPE=Bridge/) }
       it { expect(cfg_file).to match(/PREFIX=24/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }
     end
 
     context 'for lnx2lnx patchcord p_33470efd-0' do
@@ -125,7 +125,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
         expect(cfg_file).to match(/DEVICE=p_33470efd-0/)
         expect(cfg_file).to match(/BRIDGE=br1/)
         expect(cfg_file).to match(/ONBOOT=yes/)
-        expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4)
+        expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4)
       end
     end
 
@@ -141,7 +141,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
         expect(cfg_file).to match(/DEVICE=p_33470efd-1/)
         expect(cfg_file).to match(/BRIDGE=br2/)
         expect(cfg_file).to match(/ONBOOT=yes/)
-        expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4)
+        expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4)
       end
     end
 
@@ -158,7 +158,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
         expect(cfg_file).to match(/BRIDGE=br2/)
         expect(cfg_file).to match(/MTU=1800/)
         expect(cfg_file).to match(/ONBOOT=yes/)
-        expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5)
+        expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5)
       end
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__port__spec.rb
@@ -96,7 +96,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
       it { expect(cfg_file).to match(%r{TYPE=Ethernet}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }  #  no more lines in the interface file
     end
 
     context 'format file for lnx-port2 without type' do
@@ -106,7 +106,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
       it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }  #  no more lines in the interface file
     end
 
     context 'format file for lnx-port3 ethtool' do
@@ -116,7 +116,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(%r{BOOTPROTO=none}) }
       it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
       it { expect(cfg_file).to match(%r{ETHTOOL_OPTS="-K\s+lnx-port3\s+gro\s+off\s+gso\s+off\s+;"}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }  #  no more lines in the interface file
     end
 
     context "parse port lnx-port data from fixture" do

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__bond__spec.rb
@@ -90,7 +90,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(cfg_file).to match(/bond-downdelay\s+222/) }
       it { expect(cfg_file).to match(/bond-ad-select\s+2/) }
       it { expect(cfg_file).to match(/bond-xmit-hash-policy\s+encap3\+4/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(11) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(11) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__ifconfig__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__ifconfig__spec.rb
@@ -65,7 +65,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(data).to match(/iface\s+eth1\s+inet\s+static/) }
       it { expect(data).to match(/address\s+169\.254\.0\.1\/24/) }
       it { expect(data).to match(/post-up\s+sleep\s+25/) }
-      it { expect(data.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }  #  no more lines in the interface file
+      it { expect(data.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do
@@ -128,7 +128,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { p data ; expect(data).to match(/auto\s+eth1/) }
       it { expect(data).to match(/iface\s+eth1\s+inet\s+static/) }
       it { expect(data).to match(/address\s+169\.254\.0\.1\/24/) }
-      it { expect(data.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(3) }  #  no more lines in the interface file
+      it { expect(data.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(3) }  #  no more lines in the interface file
     end
   end
 end
@@ -200,7 +200,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(data).to match(/post-up\s+ip\s+addr\s+add\s+192.168.1.1\/24\s+dev\s+eth11/) }
       it { expect(data).to match(/post-up\s+ip\s+addr\s+add\s+192.168.2.2\/25\s+dev\s+eth11/) }
       it { expect(data).to match(/post-up\s+ip\s+addr\s+add\s+192.168.3.3\/26\s+dev\s+eth11/) }
-      it { expect(data.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }  #  no more lines in the interface file
+      it { expect(data.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__lnx2lnx_patch__spec.rb
@@ -99,7 +99,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br1\s+inet\s+static/) }
       it { expect(cfg_file).to match(/bridge_ports\s+p_33470efd-0/) }
       it { expect(cfg_file).to match(/address\s+192.168.88.2\/24/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }
     end
 
     context 'for LNX bridge br2' do
@@ -109,7 +109,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br2\s+inet\s+static/) }
       it { expect(cfg_file).to match(/bridge_ports\s+p_33470efd-1/) }
       it { expect(cfg_file).to match(/address\s+192.168.99.2\/24/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }
     end
 
     context 'for lnx2lnx patchcord p_33470efd-0' do
@@ -120,7 +120,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(cfg_file).to match(/pre-up\s+ip\s+link\s+add\s+p_33470efd-0\s+mtu\s+1500\s+type\s+veth\s+peer\s+name\s+p_33470efd-1\s+mtu\s+1500/) }
       it { expect(cfg_file).to match(/post-up\s+ip\s+link\s+set\s+up\s+dev\s+p_33470efd-1/) }
       it { expect(cfg_file).to match(/post-down\s+ip\s+link\s+del\s+p_33470efd-0/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }
     end
 
     context 'for lnx2lnx patchcord p_33470efd-1' do
@@ -131,7 +131,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(cfg_file).to match(/pre-up\s+ip\s+link\s+add\s+p_33470efd-0\s+mtu\s+1500\s+type\s+veth\s+peer\s+name\s+p_33470efd-1\s+mtu\s+1500/) }
       it { expect(cfg_file).to match(/post-up\s+ip\s+link\s+set\s+up\s+dev\s+p_33470efd-1/) }
       it { expect(cfg_file).to match(/post-down\s+ip\s+link\s+del\s+p_33470efd-0/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }
     end
 
     context 'for lnx2lnx patchcord p_33470efd-1 mtu 1700' do
@@ -143,7 +143,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(cfg_file).to match(/pre-up\s+ip\s+link\s+add\s+p_33470efd-0\s+mtu\s+1700\s+type\s+veth\s+peer\s+name\s+p_33470efd-1\s+mtu\s+1700/) }
       it { expect(cfg_file).to match(/post-up\s+ip\s+link\s+set\s+up\s+dev\s+p_33470efd-1/) }
       it { expect(cfg_file).to match(/post-down\s+ip\s+link\s+del\s+p_33470efd-0/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }
     end
 
 

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__port__spec.rb
@@ -69,7 +69,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       let(:cfg_file) { subject.class.format_file('filepath', [subject]) }
       it { expect(cfg_file).to match(/auto\s+p2p2/) }
       it { expect(cfg_file).to match(/iface\s+p2p2\s+inet\s+manual/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(2) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(2) }
     end
 
     context 'Phys port p2p3 with ethtool' do
@@ -79,7 +79,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+p2p3\s+inet\s+manual/) }
       it { expect(cfg_file).to match(%r{post-up\s+ethtool\s+-K\s+p2p3\s+gro\s+off\s+|\s+true\s+#\s+generic-receive-offload}) }
       it { expect(cfg_file).to match(%r{post-up\s+ethtool\s+-K\s+p2p3\s+gso\s+off\s+|\s+true\s+#\s+generic-segmentation-offload}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }
     end
 
   end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bond__spec.rb
@@ -90,7 +90,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
 other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222 lacp=active"}) }
       it { expect(cfg_file).to match(%r{BOND_IFACES="eth2 eth3"}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(9) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(9) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bridge__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bridge__spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{TYPE=OVSBridge}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__ovs2lnx_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__ovs2lnx_patch__spec.rb
@@ -102,7 +102,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{BRIDGE=lnx-br}) }
       it { expect(cfg_file).to match(%r{OVS_BRIDGE=ovs-br}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__ovs2ovs_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__ovs2ovs_patch__spec.rb
@@ -100,7 +100,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{OVS_BRIDGE=ovs-br1}) }
       it { expect(cfg_file).to match(%r{OVS_PATCH_PEER=ovs2ovs-patch2}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
     end
 
     context 'format ovs2ovs-patch2 file' do
@@ -113,7 +113,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{OVS_BRIDGE=ovs-br2}) }
       it { expect(cfg_file).to match(%r{OVS_PATCH_PEER=ovs2ovs-patch1}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
     end
 
     context 'format ovs2ovs-patch with tag file' do
@@ -127,7 +127,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{OVS_PATCH_PEER=ovs2ovs-patcht1}) }
       it { expect(cfg_file).to match(%r{OVS_OPTIONS="tag=3"}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(8) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(8) }  #  no more lines in the interface file
     end
 
     context "parse ovs2ovs-patch1 data from fixture" do

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__port__spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{TYPE=OVSPort}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(6) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_redhat7__ovs2lnx_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_redhat7__ovs2lnx_patch__spec.rb
@@ -102,7 +102,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_redhat7) do
       it { expect(cfg_file).to match(%r{BRIDGE=lnx-br}) }
       it { expect(cfg_file).to match(%r{OVS_BRIDGE=ovs-br}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bond__spec.rb
@@ -92,7 +92,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/ovs_options.+bond_updelay=111/) }
       it { expect(cfg_file).to match(/ovs_options.+bond_downdelay=222/) }
       it { expect(cfg_file).to match(/ovs_options.+lacp=active/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
 
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
@@ -75,7 +75,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br9\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSBridge/) }
       it { expect(cfg_file).to match(/mtu\s+9000/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge_with_ports__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge_with_ports__spec.rb
@@ -75,7 +75,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br8\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSBridge/) }
       it { expect(cfg_file).to match(/ovs_ports\s+ttt0\s+ttt1/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__ovs2lnx_patch__spec.rb
@@ -82,7 +82,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br-ovs\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSBridge/) }
       it { expect(cfg_file).to match(/ovs_ports\s+p_33470efd-0/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }
     end
 
     context 'for LNX bridge br1' do
@@ -92,7 +92,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br1\s+inet\s+static/) }
       it { expect(cfg_file).to match(/bridge_ports\s+p_33470efd-0/) }
       it { expect(cfg_file).to match(/address\s+192.168.88.2\/24/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }
     end
 
     context 'for ovs2lnx patchcord p_33470efd-0' do
@@ -104,7 +104,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/ovs_type\s+OVSIntPort/) }
       it { expect(cfg_file).to match(/ovs_bridge\s+br-ovs/) }
       it { expect(cfg_file).not_to match(/ovs_extra/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }
     end
   end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__ovs2ovs_patch__spec.rb
@@ -92,7 +92,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br-ovs1\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSBridge/) }
       it { expect(cfg_file).to match(/ovs_ports\s+p_33470efd-0/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }
     end
 
     context 'for OVS bridge br-ovs2' do
@@ -102,7 +102,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br-ovs2\s+inet\s+static/) }
       it { expect(cfg_file).to match(/bridge_ports\s+p_33470efd-0/) }
       it { expect(cfg_file).to match(/address\s+192.168.88.2\/24/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(4) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(4) }
     end
 
     context 'for ovs2ovs patchcord p_33470efd-0' do
@@ -115,7 +115,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/ovs_bridge\s+br-ovs1/) }
       it { expect(cfg_file).to match(/ovs_extra\s+--\s+set\s+Interface\s+p_33470efd-0\s+type=patch\s+options:peer=p_33470efd-1/) }
       it { expect(cfg_file).to match(/ovs_extra\s+--\s+set\s+Port\s+p_33470efd-0\s+tag=100/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }
     end
 
     context 'for ovs2ovs patchcord p_33470efd-1' do
@@ -128,7 +128,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/ovs_bridge\s+br-ovs2/) }
       it { expect(cfg_file).to match(/ovs_extra\s+--\s+set\s+Interface\s+p_33470efd-1\s+type=patch\s+options:peer=p_33470efd-0/) }
       it { expect(cfg_file).to match(/ovs_extra\s+--\s+set\s+Port\s+p_33470efd-1\s+tag=200/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(7) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }
     end
 
   end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__port__spec.rb
@@ -65,7 +65,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/ovs_type\s+OVSPort/) }
       it { expect(cfg_file).to match(/ovs_bridge\s+br-ovs1/) }
       it { expect(cfg_file).to match(/ovs_extra\s+--\s+set\s+Port\s+p2p1\st+ag=100/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/^\s*$/}.length). to eq(5) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }
     end
 
   end


### PR DESCRIPTION
Now it is not understandable what is managed by puppet and what is not.
This patch adds header which marks puppet managed network config files.

FUEL-Change-Id: Ieab97f550e26a5f8add0d3560999d68256415e74
FUEL-Closes-bug: #1531458

Closes: #223