### PR TITLE
Fix some misspellings in the l23network module

### DIFF
--- a/manifests/examples/run_network_scheme.pp
+++ b/manifests/examples/run_network_scheme.pp
@@ -3,11 +3,10 @@ class l23network::examples::run_network_scheme (
   $settings_yaml
 ){
 
-    class {'l23network': }
+    class {'::l23network': }
 
     $config = parseyaml($settings_yaml)
     prepare_network_config($config['network_scheme'])
     $sdn = generate_network_config()
     notice("SDN ${sdn}")
 }
-###

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,10 +41,10 @@ class l23network (
   $disable_hotplug              = true,
 ){
 
-  include stdlib
+  include ::stdlib
   include ::l23network::params
 
-  class { 'l23network::l2':
+  class { '::l23network::l2':
     ensure_package               => $ensure_package,
     use_ovs                      => $use_ovs,
     use_lnx                      => $use_lnx,
@@ -60,24 +60,24 @@ class l23network (
   }
 
   if $::l23network::params::interfaces_file {
-    if ! defined(File["${::l23network::params::interfaces_file}"]) {
-      file {"${::l23network::params::interfaces_file}":
-        ensure  => present,
-        source  => 'puppet:///modules/l23network/interfaces',
+    if ! defined(File[$::l23network::params::interfaces_file]) {
+      file { $::l23network::params::interfaces_file:
+        ensure => present,
+        source => 'puppet:///modules/l23network/interfaces',
       }
     }
-    File<| title == "${::l23network::params::interfaces_file}" |> -> File<| title == "${::l23network::params::interfaces_dir}" |>
+    File<| title == $::l23network::params::interfaces_file |> -> File<| title == $::l23network::params::interfaces_dir |>
   }
 
-  if ! defined(File["${::l23network::params::interfaces_dir}"]) {
-    file {"${::l23network::params::interfaces_dir}":
+  if ! defined(File[$::l23network::params::interfaces_dir]) {
+    file { $::l23network::params::interfaces_dir:
       ensure => directory,
       owner  => 'root',
       mode   => '0755',
     } -> Anchor['l23network::init']
   }
-  Anchor['l23network::l2::init'] -> File<| title == "${::l23network::params::interfaces_dir}" |>
-  Anchor['l23network::l2::init'] -> File<| title == "${::l23network::params::interfaces_file}" |>
+  Anchor['l23network::l2::init'] -> File<| title == $::l23network::params::interfaces_dir |>
+  Anchor['l23network::l2::init'] -> File<| title == $::l23network::params::interfaces_file |>
 
   # Centos interface up-n-down scripts
   if $::l23_os =~ /(?i:redhat|centos)/ {

--- a/manifests/l2.pp
+++ b/manifests/l2.pp
@@ -23,7 +23,8 @@ class l23network::l2 (
   $ovs_datapath_package_name    = $::l23network::params::ovs_datapath_package_name,
   $ovs_common_package_name      = $::l23network::params::ovs_common_package_name,
 ){
-  include stdlib
+
+  include ::stdlib
   include ::l23network::params
 
   if $use_ovs {
@@ -31,15 +32,15 @@ class l23network::l2 (
     if $install_ovs {
       if $use_ovs_dkms_datapath_module {
         package { 'openvswitch-datapath':
-          name   => $ovs_datapath_package_name,
           ensure => $ensure_package,
+          name   => $ovs_datapath_package_name,
         }
         Package['openvswitch-datapath'] -> Service['openvswitch-service']
       }
       if $ovs_common_package_name {
         package { 'openvswitch-common':
-          name   => $ovs_common_package_name,
           ensure => $ensure_package,
+          name   => $ovs_common_package_name,
         }
         Package['openvswitch-common'] ~> Service['openvswitch-service']
       }

--- a/manifests/l2/bond.pp
+++ b/manifests/l2/bond.pp
@@ -26,7 +26,11 @@
 #     downdelay
 #
 # [*provider*]
-#  This manifest supports lnx or ovs providers.
+#   This manifest supports lnx or ovs providers.
+#
+# [*interface_properties*]
+#   Configuration options for included interfaces (mtu, ethtool, etc...)
+#
 
 define l23network::l2::bond (
   $ensure                  = present,
@@ -38,7 +42,7 @@ define l23network::l2::bond (
   $onboot                  = undef,
   $delay_while_up          = undef,
   $bond_properties         = {},
-  $interface_properties    = undef,  # configuration options for included interfaces (mtu, ethtool, etc...)
+  $interface_properties    = undef,
   $vendor_specific         = undef,
   $monolith_bond_providers = undef,
   $provider                = undef,
@@ -167,7 +171,7 @@ define l23network::l2::bond (
   }
 
   if $delay_while_up and ! is_numeric($delay_while_up) {
-    fail("Delay for waiting after UP interface ${port} should be numeric, not an ${delay_while_up}.")
+    fail("Delay for waiting after UP interface ${bond} should be numeric, not an ${delay_while_up}.")
   }
 
   if ! $bridge and $provider == 'ovs' {
@@ -202,8 +206,8 @@ define l23network::l2::bond (
 
   if (! defined(L23network::L2::Bridge[$bridge]) and $provider == 'ovs') {
     l23network::l2::bridge { $bridge:
-      ensure    => 'present',
-      provider  => $provider,
+      ensure   => 'present',
+      provider => $provider,
     }
   }
 

--- a/manifests/l2/bond_interface.pp
+++ b/manifests/l2/bond_interface.pp
@@ -44,4 +44,3 @@ define l23network::l2::bond_interface (
     }
   }
 }
-###

--- a/manifests/l2/bridge.pp
+++ b/manifests/l2/bridge.pp
@@ -18,7 +18,7 @@ define l23network::l2::bridge (
   $stp             = undef,
   $bpdu_forward    = true,
 # $bridge_id       = undef,  # will be implemented later
-  $external_ids    = { 'bridge-id' => "${name}" },
+  $external_ids    = { 'bridge-id' => $name },
   $delay_while_up  = undef,
   $vendor_specific = undef,
   $provider        = undef,
@@ -34,7 +34,7 @@ define l23network::l2::bridge (
     }
 
     if $delay_while_up and ! is_numeric($delay_while_up) {
-      fail("Delay for waiting after UP bridge ${name} should be numeric, not an '$delay_while_up'.")
+      fail("Delay for waiting after UP bridge ${name} should be numeric, not an '${delay_while_up}'.")
     }
 
     if ! defined (L23_stored_config[$name]) {
@@ -74,7 +74,7 @@ define l23network::l2::bridge (
         ensure  => present,
         owner   => 'root',
         mode    => '0755',
-        content => template("l23network/centos_post_up.erb"),
+        content => template('l23network/centos_post_up.erb'),
       } -> L23_stored_config <| title == $name |>
     } else {
       file {"${::l23network::params::interfaces_dir}/interface-up-script-${name}":

--- a/manifests/l2/centos_upndown_scripts.pp
+++ b/manifests/l2/centos_upndown_scripts.pp
@@ -1,22 +1,22 @@
 # see http://tech.serbinn.net/2012/custom-script-on-interface-up-down-centos-and-rhel/
 class l23network::l2::centos_upndown_scripts {
   file {'/sbin/ifup-local':
-    ensure  => present,
-    owner   => 'root',
-    mode    => '0755',
-    source  => 'puppet:///modules/l23network/centos_ifup-local',
+    ensure => present,
+    owner  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/l23network/centos_ifup-local',
   } ->
   file {'/sbin/ifdown-local':
-    ensure  => present,
-    owner   => 'root',
-    mode    => '0755',
-    source  => 'puppet:///modules/l23network/centos_ifdown-local',
+    ensure => present,
+    owner  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/l23network/centos_ifdown-local',
   } ->
   file {'/sbin/ifup-pre-local':
-    ensure  => present,
-    owner   => 'root',
-    mode    => '0755',
-    source  => 'puppet:///modules/l23network/centos_ifup-pre-local',
+    ensure => present,
+    owner  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/l23network/centos_ifup-pre-local',
   } ->
   anchor { 'l23network::l2::centos_upndown_scripts': }
 }

--- a/manifests/l3/ifconfig.pp
+++ b/manifests/l3/ifconfig.pp
@@ -11,20 +11,13 @@
 #   IP address for interface. Can contain IP address, 'dhcp'
 #   or 'none' (with no IP address).
 #   Can be an array of CIDR IP addresses ['192.168.1.3/24','10.0.0.4/16']
-#   for multiple IPs on an interface. In this case netmask parameter is ignored.
-#
-# [*netmask*]
-#   Specify network mask. Default is '255.255.255.0'.
+#   for multiple IPs on an interface.
 #
 # [*gateway*]
 #   Specify default gateway if need.
 #   You can specify IP address, or 'save' for save default route
 #   if it lies through this interface now.
 #
-## [*default_gateway*]
-##   Specify if this nic and gateway should become the default route.
-##   requires that gateway is also set.
-##
 ## [*other_nets*]
 ##   Optional. Defines additional networks that this inteface can reach in CIDR
 ##   format.
@@ -69,7 +62,6 @@ define l23network::l3::ifconfig (
     $dns_search      = undef,
     $dns_domain      = undef,
     $dhcp_hostname   = undef,
-#   $dhcp_nowait     = false,
     $check_by_ping   = 'gateway',
     $check_by_ping_timeout = 30,
     #todo: label => "XXX", # -- "ip addr add..... label XXX"
@@ -92,23 +84,16 @@ define l23network::l3::ifconfig (
     $ipaddr_aliases = undef
     case $ipaddr {
       'dhcp':  {
-        $method = 'dhcp'
+        $method      = 'dhcp'
         $ipaddr_list = ['dhcp']
       }
       'none':  {
-        $method = 'manual'
+        $method      = 'manual'
         $ipaddr_list = ['none']
       }
       default: {
-        $method = 'static'
-        if $ipaddr =~ /\/\d{1,2}\s*$/ {
-          # ipaddr can be cidr-notated
-          $ipaddr_list = [$ipaddr]
-        } else {
-          # or classic pair of ipaddr+netmask
-          $cidr_notated_effective_netmask = netmask_to_cidr($netmask)
-          $ipaddr_list = ["${ipaddr}/${cidr_notated_effective_netmask}"]
-        }
+        $method      = 'static'
+        $ipaddr_list = [$ipaddr]
       }
     }
   } else {


### PR DESCRIPTION
Contain only fix for some misspellings and puppet code cleanup.

FUEL-Change-Id: I1e042048ab438b4254ee4a8d02aecdcaa6bb9332
FUEL-Closes-Bug: #1533357
FUEL-Partial-Bug: #1533240