### PR TITLE
Bond improvements

### DIFF
--- a/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
@@ -21,6 +21,7 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
       :bond_slaves    => 'ovs_bonds',
       :bond_mode      => 'ovs_options',
       :bond_miimon    => 'ovs_options',
+      :bond_use_carrier => 'ovs_options',
       :bond_lacp_rate => 'ovs_options',
       :bond_lacp      => 'ovs_options',
       :bond_xmit_hash_policy => '', # unused
@@ -57,6 +58,10 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
       },
       :bond_miimon  => {
           :field    => 'other_config:bond-miimon-interval',
+          :store_to => 'ovs_options'
+      },
+      :bond_use_carrier  => {
+          :field    => 'other_config:bond-detect-mode',
           :store_to => 'ovs_options'
       },
     }
@@ -152,6 +157,12 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
   def self.unmangle__vlan_id(provider, data)
     rv = []
     rv << "ovs_extra -- set Port #{provider.name} tag=#{provider.vlan_id}"
+  end
+
+  def self.unmangle__bond_use_carrier(provider, data)
+    values = [ 'miimon', 'carrier' ]
+    rv = values[data.to_i] if data.to_i <= values.size
+    rv ||= nil
   end
 
   def self.mangle__jacks(data)

--- a/lib/puppet/provider/l23_stored_config_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config_ubuntu.rb
@@ -42,6 +42,7 @@ class Puppet::Provider::L23_stored_config_ubuntu < Puppet::Provider::L23_stored_
       :bond_slaves           => 'bond-slaves',
       :bond_mode             => 'bond-mode',
       :bond_miimon           => 'bond-miimon',
+      :bond_use_carrier      => 'bond-use-carrier',
       :bond_lacp             => '', # unused for lnx
       :bond_lacp_rate        => 'bond-lacp-rate',
       :bond_updelay          => 'bond-updelay',

--- a/lib/puppet/provider/l2_base.rb
+++ b/lib/puppet/provider/l2_base.rb
@@ -507,6 +507,8 @@ class Puppet::Provider::L2_base < Puppet::Provider::InterfaceToolset
         :bond_properties => {
           :mode             => mode,
           :miimon           => File.open("/sys/class/net/#{bond_name}/bonding/miimon").read.chomp,
+          :updelay          => File.open("/sys/class/net/#{bond_name}/bonding/updelay").read.chomp,
+          :downdelay        => File.open("/sys/class/net/#{bond_name}/bonding/downdelay").read.chomp,
         }
       }
       if ['802.3ad', 'balance-xor', 'balance-tlb', 'balance-alb'].include? mode
@@ -515,7 +517,9 @@ class Puppet::Provider::L2_base < Puppet::Provider::InterfaceToolset
       end
       if mode=='802.3ad'
         lacp_rate = File.open("/sys/class/net/#{bond_name}/bonding/lacp_rate").read.split(/\s+/)[0]
+        ad_select = File.open("/sys/class/net/#{bond_name}/bonding/ad_select").read.split(/\s+/)[0],
         bond[bond_name][:bond_properties][:lacp_rate] = lacp_rate
+        bond[bond_name][:bond_properties][:ad_select] = ad_select
       end
       bond[bond_name][:onboot] = !self.get_iface_state(bond_name).nil?
     end

--- a/lib/puppet/type/l23_stored_config.rb
+++ b/lib/puppet/type/l23_stored_config.rb
@@ -248,6 +248,7 @@ Puppet::Type.newtype(:l23_stored_config) do
 
   newproperty(:bond_mode)
   newproperty(:bond_miimon)
+  newproperty(:bond_use_carrier)
   newproperty(:bond_lacp)
   newproperty(:bond_lacp_rate)
   newproperty(:bond_xmit_hash_policy)

--- a/lib/puppet/type/l2_bond.rb
+++ b/lib/puppet/type/l2_bond.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:l2_bond) do
       # provider-specific hash, validating only by type.
       validate do |val|
         if ! val.is_a? Hash
-          fail("Interface_properties should be a hash!")
+          fail("bond_properties should be a hash!")
         end
       end
 
@@ -139,8 +139,8 @@ Puppet::Type.newtype(:l2_bond) do
         # it's a workaround, because puppet double some values inside his internal logic
         val.keys.each do |k|
           if k.is_a? String
-            if ! val.has_key? k.to_sym
-              val[k.to_sym] = val[k]
+            unless val.has_key? k.to_sym
+              val[k.to_sym] = val[k] unless [:undef, :absent, ''].include?(val[k])
             end
             val.delete(k)
           end

--- a/spec/defines/l2_bond__spec.rb
+++ b/spec/defines/l2_bond__spec.rb
@@ -43,6 +43,17 @@ describe 'l23network::l2::bond', :type => :define do
       })
     end
 
+    it do
+      should contain_l2_bond('bond0').with({
+        'slaves'          => ['eth3', 'eth4'],
+        'bond_properties' => {:mode=>"balance-rr",
+                              :miimon=>"100",
+                              :use_carrier=>"1",
+                              :updelay=>"200",
+                              :downdelay=>"200"},
+      })
+    end
+
     ['eth3', 'eth4'].each do |slave|
       it do
         should contain_l23_stored_config(slave).with({
@@ -92,6 +103,19 @@ describe 'l23network::l2::bond', :type => :define do
       })
     end
 
+    it do
+      should contain_l2_bond('ovs-bond0').with({
+        'slaves'          => ['eth31', 'eth41'],
+        'bridge'          => 'br-ovs-bond0',
+        'bond_properties' => {:mode=>"active-backup",
+                              :miimon=>"100",
+                              :use_carrier=>"1",
+                              :lacp=>"off",
+                              :updelay=>"200",
+                              :downdelay=>"200"},
+      })
+    end
+
     ['eth31', 'eth41'].each do |slave|
       it do
         should contain_l23_stored_config(slave).with({
@@ -135,6 +159,19 @@ describe 'l23network::l2::bond', :type => :define do
         'bond_miimon' => '100',
       })
     end
+
+    it do
+      should contain_l2_bond('bond0').with({
+        'slaves'          => ['eth3.101', 'eth4.102'],
+        'bond_properties' => {:mode=>'balance-rr',
+                              :miimon=>'100',
+                              :use_carrier=>'1',
+                              :updelay=>'200',
+                              :downdelay=>'200'},
+      })
+    end
+
+
 
     ['eth3.101', 'eth4.102'].each do |slave|
       it do
@@ -183,9 +220,21 @@ describe 'l23network::l2::bond', :type => :define do
         'mtu'            => 9000,
         'bond_updelay'   => '111',
         'bond_downdelay' => '222',
-        'bond_ad_select' => 'count',
+        'bond_ad_select' => nil,
       })
     end
+
+    it do
+      should contain_l2_bond('bond0').with({
+        'slaves'          => ['eth3', 'eth4'],
+        'bond_properties' => {:mode=>'balance-rr',
+                              :miimon=>'100',
+                              :use_carrier=>'1',
+                              :updelay=>'111',
+                              :downdelay=>'222'},
+      })
+    end
+
 
     it do
       should contain_l2_bond('bond0').with({
@@ -234,16 +283,20 @@ describe 'l23network::l2::bond', :type => :define do
         'bond_xmit_hash_policy' => 'layer2',
       })
     end
-    # it do
-    #   should contain_l2_bond('bond0').with_ensure('present')
-    #   should contain_l2_bond('bond0').with_bond_properties({
-    #       :mode             => '802.3ad',
-    #       :lacp_rate        => 'slow',
-    #       :miimon           => '100',
-    #       :xmit_hash_policy => 'layer2'
-    #   })
-    # end
 
+    it do
+      should contain_l2_bond('bond0').with({
+        'slaves'          => ['eth3', 'eth4'],
+        'bond_properties' => {:mode=>'802.3ad',
+                              :xmit_hash_policy=>'layer2',
+                              :lacp_rate=>'slow',
+                              :ad_select=>'bandwidth',
+                              :miimon=>'100',
+                              :use_carrier=>'1',
+                              :updelay=>'200',
+                              :downdelay=>'200'},
+      })
+    end
     # we shouldn't test bond slaves here, because it equalent to previous tests
   end
 
@@ -275,6 +328,18 @@ describe 'l23network::l2::bond', :type => :define do
       should contain_l23_stored_config('bond0').without_bond_lacp_rate()
       should contain_l23_stored_config('bond0').without_bond_xmit_hash_policy()
     end
+
+    it do
+      should contain_l2_bond('bond0').with({
+        'slaves'          => ['eth3', 'eth4'],
+        'bond_properties' => {:mode=>'active-backup',
+                              :miimon=>'100',
+                              :use_carrier=>'1',
+                              :updelay=>'200',
+                              :downdelay=>'200'},
+      })
+    end
+
   end
 
   context 'Create a lnx-bond with mode = balance-tlb, lacp_rate = fast xmit_hash_policy = layer2+3' do
@@ -386,8 +451,8 @@ describe 'l23network::l2::bond', :type => :define do
         'bond_lacp'             => 'active',
         'bond_lacp_rate'        => 'fast',
         'bond_miimon'           => '300',
-        'bond_updelay'          => '200',
-        'bond_downdelay'        => '200',
+        'bond_updelay'          => '600',
+        'bond_downdelay'        => '600',
       })
       should contain_l23_stored_config('bond-ovs').without_bond_xmit_hash_policy()
     end
@@ -398,9 +463,10 @@ describe 'l23network::l2::bond', :type => :define do
           :mode             => 'balance-tcp',
           :lacp             => 'active',
           :lacp_rate        => 'fast',
+          :use_carrier      => '1',
           :miimon           => '300',
-          :updelay          =>"200",
-          :downdelay        =>"200",
+          :updelay          => '600',
+          :downdelay        => '600',
         },
       })
     end

--- a/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-lnx-bond1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-lnx-bond1
@@ -10,4 +10,4 @@ ONBOOT=yes
 MTU=9000
 TYPE=Bond
 BRIDGE=lnx-br0
-BONDING_OPTS="mode=balance-tcp miimon=60 lacp_rate=fast ad_select=2 updelay=123 downdelay=155"
+BONDING_OPTS="mode=balance-tcp miimon=60 use_carrier=0 lacp_rate=fast ad_select=2 updelay=123 downdelay=155"

--- a/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-ovs-bondlacp1
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bonds/ifcfg-ovs-bondlacp1
@@ -10,6 +10,6 @@ ONBOOT=yes
 MTU=9000
 TYPE=OVSBond
 OVS_BRIDGE=br0
-OVS_OPTIONS="bond_mode=balance-tcp other_config:bond-miimon-interval=50 lacp=active other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222"
+OVS_OPTIONS="bond_mode=balance-tcp other_config:bond-miimon-interval=50 other_config:bond-detect-mode=miimon lacp=active other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222"
 DEVICETYPE=ovs
 BOND_IFACES="eth2 eth3"

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_centos7__bond__spec.rb
@@ -14,22 +14,23 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
   let(:input_data) do
     {
       :lnx_bond1 => {
-        :name           => 'lnx-bond1',
-        :ensure         => 'present',
-        :if_type        => 'bond',
-        :bridge         => 'lnx-br0',
-        :mtu            => '9000',
-        :onboot         => true,
-        :method         => 'manual',
-        :bond_mode      => 'balance-tcp',
-        :bond_slaves    => ['eth2', 'eth3'],
-        :bond_miimon    => '60',
-        :bond_lacp_rate => 'fast',
-        :bond_lacp      => 'active',
-        :bond_updelay   => '123',
-        :bond_downdelay => '155',
-        :bond_ad_select => '2',   # unused for OVS
-        :provider       => "lnx_centos7",
+        :name             => 'lnx-bond1',
+        :ensure           => 'present',
+        :if_type          => 'bond',
+        :bridge           => 'lnx-br0',
+        :mtu              => '9000',
+        :onboot           => true,
+        :method           => 'manual',
+        :bond_mode        => 'balance-tcp',
+        :bond_slaves      => ['eth2', 'eth3'],
+        :bond_miimon      => '60',
+        :bond_use_carrier => '0',
+        :bond_lacp_rate   => 'fast',
+        :bond_lacp        => 'active',
+        :bond_updelay     => '123',
+        :bond_downdelay   => '155',
+        :bond_ad_select   => '2',   # unused for OVS
+        :provider         => "lnx_centos7",
       },
     }
   end
@@ -86,7 +87,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(cfg_file).to match(%r{TYPE=Bond}) }
       it { expect(cfg_file).to match(%r{BRIDGE=lnx-br0}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
-      it { expect(cfg_file).to match(%r{BONDING_OPTS="mode=balance-tcp miimon=60 lacp_rate=fast ad_select=2 updelay=123 downdelay=155"}) }
+      it { expect(cfg_file).to match(%r{BONDING_OPTS="mode=balance-tcp miimon=60 use_carrier=0 lacp_rate=fast ad_select=2 updelay=123 downdelay=155"}) }
       it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
 
     end
@@ -99,6 +100,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_centos7) do
       it { expect(res[:if_type].to_s).to eq 'bond' }
       it { expect(res[:bond_mode]).to eq 'balance-tcp' }
       it { expect(res[:bond_miimon]).to eq '60' }
+      it { expect(res[:bond_use_carrier]).to eq '0' }
       it { expect(res[:bond_lacp_rate]).to eq 'fast' }
       it { expect(res[:bond_lacp]).not_to eq 'active' }
       it { expect(res[:bond_updelay]).to eq '123' }

--- a/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/lnx_ubuntu__bond__spec.rb
@@ -6,22 +6,22 @@ describe Puppet::Type.type(:l23_stored_config).provider(:lnx_ubuntu) do
   let(:input_data) do
     {
       :bond0 => {
-        :name           => 'bond0',
-        :ensure         => 'present',
-        :if_type        => 'bond',
-        :mtu            => '9000',
-        :onboot         => true,
-        :method         => 'manual',
-        :bond_mode      => '802.3ad',
+        :name                  => 'bond0',
+        :ensure                => 'present',
+        :if_type               => 'bond',
+        :mtu                   => '9000',
+        :onboot                => true,
+        :method                => 'manual',
+        :bond_mode             => '802.3ad',
         :bond_xmit_hash_policy => 'encap3+4',
-        :bond_slaves    => ['eth2', 'eth3'],
-        :bond_miimon    => '50',
-        :bond_lacp_rate => 'fast',
-        :bond_lacp      => 'passive',  # used only for OVS bonds. Should do nothing for lnx.
-        :bond_updelay   => '111',
-        :bond_downdelay => '222',
-        :bond_ad_select => '2',
-        :provider       => "lnx_ubuntu",
+        :bond_slaves           => ['eth2', 'eth3'],
+        :bond_miimon           => '50',
+        :bond_lacp_rate        => 'fast',
+        :bond_lacp             => 'passive',  # used only for OVS bonds. Should do nothing for lnx.
+        :bond_updelay          => '111',
+        :bond_downdelay        => '222',
+        :bond_ad_select        => '2',
+        :provider              => "lnx_ubuntu",
       },
     }
   end

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bond__spec.rb
@@ -14,22 +14,23 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
   let(:input_data) do
     {
       :ovs_bondlacp1 => {
-        :name           => 'ovs-bondlacp1',
-        :ensure         => 'present',
-        :if_type        => 'bond',
-        :bridge         => 'br0',
-        :mtu            => '9000',
-        :onboot         => true,
-        :method         => 'manual',
-        :bond_mode      => 'balance-tcp',
-        :bond_slaves    => ['eth2', 'eth3'],
-        :bond_miimon    => '50',
-        :bond_lacp_rate => 'fast',
-        :bond_lacp      => 'active',
-        :bond_updelay   => '111',
-        :bond_downdelay => '222',
-        :bond_ad_select => '2',   # unused for OVS
-        :provider       => "ovs_centos7",
+        :name             => 'ovs-bondlacp1',
+        :ensure           => 'present',
+        :if_type          => 'bond',
+        :bridge           => 'br0',
+        :mtu              => '9000',
+        :onboot           => true,
+        :method           => 'manual',
+        :bond_mode        => 'balance-tcp',
+        :bond_slaves      => ['eth2', 'eth3'],
+        :bond_miimon      => '50',
+        :bond_use_carrier => '0',
+        :bond_lacp_rate   => 'fast',
+        :bond_lacp        => 'active',
+        :bond_updelay     => '111',
+        :bond_downdelay   => '222',
+        :bond_ad_select   => '2',   # unused for OVS
+        :provider         => "ovs_centos7",
       },
     }
   end
@@ -87,7 +88,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{OVS_BRIDGE=br0}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
       it { expect(cfg_file).to match(%r{OVS_OPTIONS="bond_mode=balance-tcp other_config:bond-miimon-interval=50 \
-other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222 lacp=active"}) }
+other_config:bond-detect-mode=miimon other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222 lacp=active"}) }
       it { expect(cfg_file).to match(%r{BOND_IFACES="eth2 eth3"}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
       it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(9) }  #  no more lines in the interface file
@@ -101,6 +102,7 @@ other_config:lacp-time=fast bond_updelay=111 bond_downdelay=222 lacp=active"}) }
       it { expect(res[:if_type].to_s).to eq 'bond' }
       it { expect(res[:bond_mode]).to eq 'balance-tcp' }
       it { expect(res[:bond_miimon]).to eq '50' }
+      it { expect(res[:bond_use_carrier].to_s).to eq '0' }
       it { expect(res[:bond_lacp_rate]).to eq 'fast' }
       it { expect(res[:bond_lacp]).to eq 'active' }
       it { expect(res[:bond_updelay]).to eq '111' }

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bond__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bond__spec.rb
@@ -6,22 +6,23 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
   let(:input_data) do
     {
       :bond_lacp => {
-        :name           => 'bond_lacp',
-        :ensure         => 'present',
-        :if_type        => 'bond',
-        :bridge         => 'br0',
-        :mtu            => '9000',
-        :onboot         => true,
-        :method         => 'manual',
-        :bond_mode      => 'balance-tcp',
-        :bond_slaves    => ['eth2', 'eth3'],
-        :bond_miimon    => '50',
-        :bond_lacp_rate => 'fast',
-        :bond_lacp      => 'active',
-        :bond_updelay   => '111',
-        :bond_downdelay => '222',
-        :bond_ad_select => '2',   # unused for OVS
-        :provider       => "ovs_ubuntu",
+        :name             => 'bond_lacp',
+        :ensure           => 'present',
+        :if_type          => 'bond',
+        :bridge           => 'br0',
+        :mtu              => '9000',
+        :onboot           => true,
+        :method           => 'manual',
+        :bond_mode        => 'balance-tcp',
+        :bond_slaves      => ['eth2', 'eth3'],
+        :bond_miimon      => '50',
+        :bond_use_carrier => '0',
+        :bond_lacp_rate   => 'fast',
+        :bond_lacp        => 'active',
+        :bond_updelay     => '111',
+        :bond_downdelay   => '222',
+        :bond_ad_select   => '2',   # unused for OVS
+        :provider         => "ovs_ubuntu",
       },
     }
   end
@@ -87,6 +88,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/ovs_type\s+OVSBond/) }
       it { expect(cfg_file).to match(/ovs_bridge\s+br0/) }
       it { expect(cfg_file).to match(/ovs_options.+bond_mode=balance-tcp/) }
+      it { expect(cfg_file).to match(/ovs_options.+other_config:bond-detect-mode=miimon/) }
       it { expect(cfg_file).to match(/ovs_options.+other_config:lacp-time=fast/) }
       it { expect(cfg_file).to match(/ovs_options.+other_config:bond-miimon-interval=50/) }
       it { expect(cfg_file).to match(/ovs_options.+bond_updelay=111/) }


### PR DESCRIPTION
* Set correct default bond properties:
  - ad_select is only used for 802.3ad bond mode
  - Implement bond property *use_carrier*
  - updelay and downdelay values are connected with miimon value
* Fix idempotency for resource l2_bond:
  - Skip undef, absent and '' for bond_properties in type
  - Add to prefetching such bond_properties as ad_select, updelay and downdelay
    for lnx provider.

FUEL-Change-Id: If66f312a7cfeb10c5e3a94ff90635d2671790286
FUEL-Closes-bug: #1536246

Closes: #231