### PR TITLE
Disable NetworkManager by default

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,16 @@
+# For a standalone version should be:
+#
+# fixtures:
+#   forge_modules:
+#     stdlib:
+#       repo: "puppetlabs/stdlib"
+#       ref:  "4.9.0"
+#     filemapper:
+#       repo: "adrien/filemapper"
+#       ref:  "1.1.3"
+#   symlinks:
+#     l23network: "#{source_dir}"
+
 fixtures:
   repositories:
     'stdlib': 'git://github.com/puppetlabs/puppetlabs-stdlib.git'

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,7 @@ lib/bundler/man
 pkg
 rdoc
 spec/reports
-spec/fixtures/modules/filemapper
-spec/fixtures/modules/stdlib
-spec/fixtures/modules/sysctl
+spec/fixtures/modules
 test/tmp
 test/version_tmp
 tmp

--- a/manifests/examples/run_network_scheme.pp
+++ b/manifests/examples/run_network_scheme.pp
@@ -3,6 +3,13 @@ class l23network::examples::run_network_scheme (
   $settings_yaml
 ){
 
+    include ::l23network::params
+
+    # this is a workaround for run spec tests not only on Linux platform
+    if $::l23network::params::network_manager_name != undef {
+      Package<| title == $::l23network::params::network_manager_name |> { provider => apt }
+    }
+
     class {'::l23network': }
 
     $config = parseyaml($settings_yaml)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,20 +98,24 @@ class l23network (
   Anchor['l23network::l2::init'] -> Anchor['l23network::init']
   anchor { 'l23network::init': }
 
-  unless $network_manager {
-    package{$::l23network::params::network_manager_name:
-      ensure => 'purged',
+  if ! $network_manager {
+    if $::l23network::params::network_manager_name != undef {
+      package{$::l23network::params::network_manager_name:
+        ensure => 'purged',
+      }
+      Package[$::l23network::params::network_manager_name] -> Anchor['l23network::init']
     }
-    Package[$::l23network::params::network_manager_name] -> Anchor['l23network::init']
 
     # It is not enough to just remove package, we have to stop the service as well.
     # Because SystemD continues running the service after package removing,
     # with Upstart - all is ok.
-    if $::l23_os =~ /(?i:redhat7|centos7)/ {
+    if $::l23_os =~ /(?i)redhat7|centos7/ {
       service{$::l23network::params::network_manager_name:
         ensure => 'stopped',
       }
-      Package[$::l23network::params::network_manager_name] ~> Service[$::l23network::params::network_manager_name]
+      if $::l23network::params::network_manager_name != undef {
+        Package[$::l23network::params::network_manager_name] ~> Service[$::l23network::params::network_manager_name]
+      }
       Service[$::l23network::params::network_manager_name] -> Anchor['l23network::init']
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class l23network::params {
       $network_manager_name      = 'network-manager'
       $extra_tools               = 'iputils-arping'
     }
-    /(?i:redhat|centos)/: {
+    /(?i)redhat|centos/: {
       $interfaces_dir            = '/etc/sysconfig/network-scripts'
       $interfaces_file           = undef
       $ovs_service_name          = 'openvswitch'
@@ -44,10 +44,11 @@ class l23network::params {
       $lnx_bridge_tools          = undef
       $ovs_datapath_package_name = undef
       $ovs_common_package_name   = undef
-      $ovs_kern_module_name      = unedf
+      $ovs_kern_module_name      = undef
+      $network_manager_name      = undef
     }
     default: {
-      fail("Unsupported OS: ${::l23_os}/${::operatingsystem}")
+      fail("Unsupported OS: ${l23_os}/${::operatingsystem}")
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class l23network::params {
       $ovs_datapath_package_name = undef
       $ovs_common_package_name   = 'openvswitch-switch'
       $ovs_kern_module_name      = 'openvswitch'
+      $network_manager_name      = 'network-manager'
       $extra_tools               = 'iputils-arping'
     }
     /(?i:redhat|centos)/: {
@@ -30,6 +31,7 @@ class l23network::params {
       $ovs_datapath_package_name = 'kmod-openvswitch'
       $ovs_common_package_name   = 'openvswitch'
       $ovs_kern_module_name      = 'openvswitch'
+      $network_manager_name      = 'NetworkManager'
       $extra_tools               = 'iputils'
     }
     /(?i)darwin/: {

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": ["6.5"]
+      "operatingsystemrelease": ["6.5", "7.0", "7.1"]
     },
     {
       "operatingsystem": "Ubuntu",
@@ -24,7 +24,6 @@
   "description": "Configure network features for 2nd and 3d network level.",
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.0.0 <5.0.0" },
-    { "name": "duritong/sysctl", "version_requirement": ">=0.0.1 <1.0.0" },
     { "name": "adrien/filemapper", "version_requirement": ">=1.1.3" }
   ]
 }

--- a/spec/classes/l23network_init__spec.rb
+++ b/spec/classes/l23network_init__spec.rb
@@ -19,17 +19,15 @@ describe 'l23network', :type => :class do
       should compile.with_all_deps
     end
 
-    it do
-      should contain_package('bridge-utils').with_ensure('present')
-      should contain_package('ethtool').with_ensure('present')
-      should contain_package('ifenslave').with_ensure('present')
-      should contain_package('vlan').with_ensure('present')
-      should contain_package('network-manager').with_ensure('purged')
-      should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]')
-      should contain_anchor('l23network::l2::init').that_requires('Package[vlan]')
-      should contain_anchor('l23network::l2::init').that_requires('Package[ifenslave]')
-      should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]')
-    end
+    it { should contain_package('bridge-utils').with_ensure('present') }
+    it { should contain_package('ethtool').with_ensure('present') }
+    it { should contain_package('ifenslave').with_ensure('present') }
+    it { should contain_package('vlan').with_ensure('present') }
+    it { should contain_package('network-manager').with_ensure('purged') }
+    it { should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]') }
+    it { should contain_anchor('l23network::l2::init').that_requires('Package[vlan]') }
+    it { should contain_anchor('l23network::l2::init').that_requires('Package[ifenslave]') }
+    it { should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]') }
   end
 
   context 'default init of l23network module(CentOS6)' do
@@ -48,16 +46,15 @@ describe 'l23network', :type => :class do
       should compile.with_all_deps
     end
 
-    it do
-      should contain_package('bridge-utils').with_ensure('present')
-      should contain_package('ethtool').with_ensure('present')
-      should_not contain_package('ifenslave').with_ensure('present')
-      should_not contain_package('vlan').with_ensure('present')
-      should contain_package('NetworkManager').with_ensure('purged')
-      should_not contain_service('NetworkManager').with_ensure('stopped')
-      should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]')
-      should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]')
-    end
+    it { should contain_package('bridge-utils').with_ensure('present') }
+    it { should contain_package('ethtool').with_ensure('present') }
+    it { should_not contain_package('ifenslave').with_ensure('present') }
+    it { should_not contain_package('vlan').with_ensure('present') }
+    it { should contain_package('NetworkManager').with_ensure('purged') }
+    it { should_not contain_service('NetworkManager').with_ensure('stopped') }
+    it { should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]') }
+    it { should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]') }
+
   end
 
   context 'default init of l23network module(CentOS7/RHEL7)' do
@@ -76,16 +73,13 @@ describe 'l23network', :type => :class do
       should compile.with_all_deps
     end
 
-    it do
-      should contain_package('bridge-utils').with_ensure('present')
-      should contain_package('ethtool').with_ensure('present')
-      should_not contain_package('ifenslave').with_ensure('present')
-      should_not contain_package('vlan').with_ensure('present')
-      should contain_package('NetworkManager').with_ensure('purged')
-      should contain_service('NetworkManager').with_ensure('stopped')
-      should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]')
-      should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]')
-    end
+    it { should contain_package('bridge-utils').with_ensure('present') }
+    it { should contain_package('ethtool').with_ensure('present') }
+    it { should_not contain_package('ifenslave').with_ensure('present') }
+    it { should_not contain_package('vlan').with_ensure('present') }
+    it { should contain_package('NetworkManager').with_ensure('purged') }
+    it { should contain_service('NetworkManager').with_ensure('stopped') }
+    it { should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]') }
   end
 
   context 'init l23network module with enabled OVS' do
@@ -114,11 +108,11 @@ describe 'l23network', :type => :class do
       should contain_package('openvswitch-common').with({
         'name'   => 'openvswitch-switch'
       })
-      should contain_package('bridge-utils').with_ensure('present')
-      should contain_package('ethtool').with_ensure('present')
-      should contain_package('ifenslave').with_ensure('present')
-      should contain_package('vlan').with_ensure('present')
     end
+    it { should contain_package('bridge-utils').with_ensure('present') }
+    it { should contain_package('ethtool').with_ensure('present') }
+    it { should contain_package('ifenslave').with_ensure('present') }
+    it { should contain_package('vlan').with_ensure('present') }
 
     it do
       should contain_service('openvswitch-service').with({
@@ -153,13 +147,13 @@ describe 'l23network', :type => :class do
     it 'without OVS, should not contain packages' do
       should contain_package('bridge-utils').with(
         :ensure => 'absent' )
-      should contain_package('ethtool').with(
-        :ensure => 'absent' )
-      should contain_package('ifenslave').with(
-        :ensure => 'absent' )
-      should contain_package('vlan').with(
-        :ensure => 'absent' )
     end
+    it { should contain_package('ethtool').with(
+        :ensure => 'absent' ) }
+    it { should contain_package('ifenslave').with(
+        :ensure => 'absent' ) }
+    it { should contain_package('vlan').with(
+        :ensure => 'absent' ) }
 
     let(:params) { {
       :ensure_package => 'absent',
@@ -169,16 +163,15 @@ describe 'l23network', :type => :class do
     it 'with OVS, should not contain packages' do
       should contain_package('bridge-utils').with(
         :ensure => 'absent' )
-      should contain_package('ethtool').with(
-        :ensure => 'absent' )
-      should contain_package('ifenslave').with(
-        :ensure => 'absent' )
-      should contain_package('vlan').with(
-        :ensure => 'absent' )
-      should contain_package('openvswitch-common').with(
-        :ensure => 'absent' )
     end
-
+    it { should contain_package('ethtool').with(
+        :ensure => 'absent' ) }
+    it { should contain_package('ifenslave').with(
+        :ensure => 'absent' ) }
+    it { should contain_package('vlan').with(
+        :ensure => 'absent' ) }
+    it { should contain_package('openvswitch-common').with(
+        :ensure => 'absent' ) }
   end
 
 end

--- a/spec/classes/l23network_init__spec.rb
+++ b/spec/classes/l23network_init__spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 
 describe 'l23network', :type => :class do
 
-  context 'default init of l23network module' do
-#    let(:title) { 'empty network scheme' }
+  context 'default init of l23network module(Ubuntu)' do
     let(:facts) { {
       :osfamily => 'Debian',
       :operatingsystem => 'Ubuntu',
@@ -25,9 +24,66 @@ describe 'l23network', :type => :class do
       should contain_package('ethtool').with_ensure('present')
       should contain_package('ifenslave').with_ensure('present')
       should contain_package('vlan').with_ensure('present')
+      should contain_package('network-manager').with_ensure('purged')
       should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]')
       should contain_anchor('l23network::l2::init').that_requires('Package[vlan]')
       should contain_anchor('l23network::l2::init').that_requires('Package[ifenslave]')
+      should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]')
+    end
+  end
+
+  context 'default init of l23network module(CentOS6)' do
+    let(:facts) { {
+      :operatingsystem => 'CentOS',
+      :kernel => 'Linux',
+      :l23_os => 'centos6',
+      :l3_fqdn_hostname => 'stupid_hostname',
+    } }
+
+    before(:each) do
+      puppet_debug_override()
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_package('bridge-utils').with_ensure('present')
+      should contain_package('ethtool').with_ensure('present')
+      should_not contain_package('ifenslave').with_ensure('present')
+      should_not contain_package('vlan').with_ensure('present')
+      should contain_package('NetworkManager').with_ensure('purged')
+      should_not contain_service('NetworkManager').with_ensure('stopped')
+      should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]')
+      should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]')
+    end
+  end
+
+  context 'default init of l23network module(CentOS7/RHEL7)' do
+    let(:facts) { {
+      :operatingsystem => 'CentOS',
+      :kernel => 'Linux',
+      :l23_os => 'centos7',
+      :l3_fqdn_hostname => 'stupid_hostname',
+    } }
+
+    before(:each) do
+      puppet_debug_override()
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_package('bridge-utils').with_ensure('present')
+      should contain_package('ethtool').with_ensure('present')
+      should_not contain_package('ifenslave').with_ensure('present')
+      should_not contain_package('vlan').with_ensure('present')
+      should contain_package('NetworkManager').with_ensure('purged')
+      should contain_service('NetworkManager').with_ensure('stopped')
+      should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]')
       should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]')
     end
   end

--- a/spec/classes/l23network_init__spec.rb
+++ b/spec/classes/l23network_init__spec.rb
@@ -15,10 +15,7 @@ describe 'l23network', :type => :class do
       puppet_debug_override()
     end
 
-    it do
-      should compile.with_all_deps
-    end
-
+    it { should compile.with_all_deps }
     it { should contain_package('bridge-utils').with_ensure('present') }
     it { should contain_package('ethtool').with_ensure('present') }
     it { should contain_package('ifenslave').with_ensure('present') }
@@ -28,6 +25,7 @@ describe 'l23network', :type => :class do
     it { should contain_anchor('l23network::l2::init').that_requires('Package[vlan]') }
     it { should contain_anchor('l23network::l2::init').that_requires('Package[ifenslave]') }
     it { should contain_anchor('l23network::l2::init').that_requires('Package[ethtool]') }
+
   end
 
   context 'default init of l23network module(CentOS6)' do
@@ -42,10 +40,7 @@ describe 'l23network', :type => :class do
       puppet_debug_override()
     end
 
-    it do
-      should compile.with_all_deps
-    end
-
+    it { should compile.with_all_deps }
     it { should contain_package('bridge-utils').with_ensure('present') }
     it { should contain_package('ethtool').with_ensure('present') }
     it { should_not contain_package('ifenslave').with_ensure('present') }
@@ -69,10 +64,7 @@ describe 'l23network', :type => :class do
       puppet_debug_override()
     end
 
-    it do
-      should compile.with_all_deps
-    end
-
+    it { should compile.with_all_deps }
     it { should contain_package('bridge-utils').with_ensure('present') }
     it { should contain_package('ethtool').with_ensure('present') }
     it { should_not contain_package('ifenslave').with_ensure('present') }
@@ -80,6 +72,7 @@ describe 'l23network', :type => :class do
     it { should contain_package('NetworkManager').with_ensure('purged') }
     it { should contain_service('NetworkManager').with_ensure('stopped') }
     it { should contain_anchor('l23network::l2::init').that_comes_before('Anchor[l23network::init]') }
+
   end
 
   context 'init l23network module with enabled OVS' do

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -1,1 +1,7 @@
 include ::l23network::params
+
+# this is a workaround for run spec tests not only on Linux platform
+if $::l23network::params::network_manager_name != undef {
+  Package<| title == $::l23network::params::network_manager_name |> { provider => apt }
+}
+###


### PR DESCRIPTION
Add the possibility to use NetworkManager or not, but disabled by default.
It is not recommended because it leads to unpredictable behaviour.

FUEL-Change-Id: I8e080fd5e4ceac9e2e26dafdf50e7f11fb6c8f04
FUEL-Closes-bug: #1538757

Closes: #234