### PR TITLE
Set datapath_type for ovs bridge

### DIFF
--- a/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_ubuntu.rb
@@ -145,6 +145,10 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
           :detect_re    => /(ovs_)?extra\s+--\s+set\s+Port\s+(.*[\d+])\s+tag=(\d+)/,
           :detect_shift => 3,
       },
+      :datapath_type  => {
+          :detect_re    => /(ovs_)?extra\s+set\s+Bridge\s+([a-z][0-9a-z\-]*[0-9a-z])\s+datapath_type=([a-z]+)/,
+          :detect_shift => 3,
+      },
     })
     return rv
   end
@@ -170,6 +174,19 @@ Puppet::Type.type(:l23_stored_config).provide(:ovs_ubuntu, :parent => Puppet::Pr
   end
 
   def self.mangle__vlan_id(data)
+    data.join()
+  end
+
+  def self.unmangle__datapath_type(provider, val)
+    if provider.if_type.to_s == 'bridge'
+      if provider.datapath_type
+        rv = []
+        rv << "ovs_extra set Bridge #{provider.name} datapath_type=#{provider.datapath_type}"
+      end
+    end
+  end
+
+  def self.mangle__datapath_type(data)
     data.join()
   end
 

--- a/lib/puppet/provider/l23_stored_config_ovs_centos.rb
+++ b/lib/puppet/provider/l23_stored_config_ovs_centos.rb
@@ -19,6 +19,7 @@ class Puppet::Provider::L23_stored_config_ovs_centos < Puppet::Provider::L23_sto
       :bond_updelay     => 'bond_updelay',
       :bond_downdelay   => 'bond_downdelay',
       :bonding_opts     => 'OVS_OPTIONS',
+      :datapath_type    => 'OVS_EXTRA',
     })
     #delete non-OVS params
     [:bond_ad_select, :bond_xmit_hash_policy, :bond_master].each { |p| rv.delete(p) }
@@ -190,6 +191,18 @@ class Puppet::Provider::L23_stored_config_ovs_centos < Puppet::Provider::L23_sto
     rv ||= nil
   end
 
+  def self.unmangle__datapath_type(provider, val)
+    if provider.if_type.to_s == 'bridge'
+      if provider.datapath_type
+        "\"set Bridge #{provider.name} datapath_type=#{provider.datapath_type}\""
+      end
+    end
+  end
+
+  def self.mangle__datapath_type(data)
+    val = data.match(/set\s+Bridge\s+([a-z][0-9a-z\-]*[0-9a-z])\s+datapath_type=([a-z]+)/)[2]
+    val
+  end
 end
 
 # vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l2_base.rb
+++ b/lib/puppet/provider/l2_base.rb
@@ -158,6 +158,7 @@ class Puppet::Provider::L2_base < Puppet::Provider::InterfaceToolset
             :external_ids  => ovs_parse_opthash(buff['external_ids']),
             :other_config  => ovs_parse_opthash(buff['other_config']),
             :status        => ovs_parse_opthash(buff['status']),
+            :datapath_type => buff['datapath_type'],
           }
         }
         debug("Found OVS br: '#{buff['name']}' with properties: #{rv[buff['name']]}")

--- a/lib/puppet/provider/l2_bridge/ovs.rb
+++ b/lib/puppet/provider/l2_bridge/ovs.rb
@@ -52,6 +52,10 @@ Puppet::Type.type(:l2_bridge).provide(:ovs, :parent => Puppet::Provider::Ovs_bas
           end
         end
       end
+      vs = (@property_flush[:vendor_specific] || {})
+      if vs.has_key? :datapath_type
+        vsctl('set', 'Bridge', @resource[:bridge], "datapath_type=#{vs[:datapath_type]}")
+      end
       #
       @property_hash = resource.to_hash
     end
@@ -80,7 +84,10 @@ Puppet::Type.type(:l2_bridge).provide(:ovs, :parent => Puppet::Provider::Ovs_bas
     @property_hash[:vendor_specific] || :absent
   end
   def vendor_specific=(val)
-    @property_flush[:vendor_specific] = val
+    old = @property_hash[:vendor_specific] || {}
+    # we're prefetching properties as hashes w/ keys as symbols, and set props as hashes w/ keys as strings
+    # so here is normalization
+    @property_flush[:vendor_specific] = Hash[val.map{|(k,v)| [k,v] if old[k.to_sym] != v }]
   end
 
   def stp

--- a/lib/puppet/type/l23_stored_config.rb
+++ b/lib/puppet/type/l23_stored_config.rb
@@ -336,6 +336,16 @@ Puppet::Type.newtype(:l23_stored_config) do
     end
   end
 
+  newproperty(:datapath_type) do
+    desc "OVS datapath type"
+    newvalues(/^\w+$/, "", :none, :undef, :nil, :absent)
+    aliasvalue("",  :absent)
+    aliasvalue(:none,  :absent)
+    aliasvalue(:undef, :absent)
+    aliasvalue(:nil,   :absent)
+    defaultto :absent
+  end
+
   newproperty(:vendor_specific) do
     desc "Hash of vendor specific properties"
     #defaultto {}  # no default value should be!!!

--- a/manifests/l2/bridge.pp
+++ b/manifests/l2/bridge.pp
@@ -20,7 +20,7 @@ define l23network::l2::bridge (
 # $bridge_id       = undef,  # will be implemented later
   $external_ids    = { 'bridge-id' => $name },
   $delay_while_up  = undef,
-  $vendor_specific = undef,
+  $vendor_specific = {},
   $provider        = undef,
 ) {
   include ::stdlib
@@ -49,6 +49,7 @@ define l23network::l2::bridge (
       bridge_ports    => ['none'],  # this property will be fulled by l2_port
       vendor_specific => $vendor_specific,
       delay_while_up  => $delay_while_up,
+      datapath_type   => $vendor_specific['datapath_type'],
       provider        => $config_provider
     }
 

--- a/spec/defines/l2_bridge__spec.rb
+++ b/spec/defines/l2_bridge__spec.rb
@@ -35,6 +35,7 @@ describe 'l23network::l2::bridge', :type => :define do
         'ipaddr'     => nil,
         'gateway'    => nil,
         'bridge_stp' => nil,
+        'vendor_specific' => {},
       })
     end
 
@@ -192,6 +193,7 @@ describe 'l23network::l2::bridge', :type => :define do
         'if_type'      => 'bridge',
         'bridge_ports' => ['none'],
         'provider'     => nil,
+        'vendor_specific' => {},
       })
     end
 
@@ -202,6 +204,7 @@ describe 'l23network::l2::bridge', :type => :define do
         'external_ids' => { 'bridge-id' => 'br-floating' },
         'stp'          => nil,
         'provider'     => nil,
+        'vendor_specific' => {},
       }).that_requires('L23_stored_config[br-floating]')
     end
   end
@@ -226,6 +229,7 @@ describe 'l23network::l2::bridge', :type => :define do
         'if_type'      => 'bridge',
         'bridge_ports' => ['none'],
         'provider'     => nil,
+        'vendor_specific' => {},
       })
     end
 
@@ -236,6 +240,7 @@ describe 'l23network::l2::bridge', :type => :define do
         'external_ids' => { 'bridge-id' => 'br-floating' },
         'stp'          => nil,
         'provider'     => nil,
+        'vendor_specific' => {},
       }).that_requires('L23_stored_config[br-floating]')
     end
   end

--- a/spec/fixtures/provider/l23_stored_config/centos7_bridges/ifcfg-ovs-bridge
+++ b/spec/fixtures/provider/l23_stored_config/centos7_bridges/ifcfg-ovs-bridge
@@ -9,4 +9,5 @@ DEVICE=ovs-bridge
 ONBOOT=yes
 MTU=9000
 TYPE=OVSBridge
+OVS_EXTRA="set Bridge ovs-bridge datapath_type=netdev"
 DEVICETYPE=ovs

--- a/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge
+++ b/spec/fixtures/provider/l23_stored_config/ovs_ubuntu__spec/ifcfg-bridge
@@ -8,3 +8,4 @@ allow-ovs br9
 iface br9 inet manual
   ovs_type OVSBridge
   mtu 9000
+  ovs_extra set Bridge br9 datapath_type=netdev

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bridge__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_centos7__bridge__spec.rb
@@ -21,6 +21,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
         :onboot         => true,
         :method         => 'manual',
         :provider       => 'ovs_centos7',
+        :datapath_type  => "netdev",
       },
     }
   end
@@ -76,8 +77,9 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(cfg_file).to match(%r{ONBOOT=yes}) }
       it { expect(cfg_file).to match(%r{TYPE=OVSBridge}) }
       it { expect(cfg_file).to match(%r{MTU=9000}) }
+      it { expect(cfg_file).to match(%r{OVS_EXTRA="set Bridge ovs-bridge datapath_type=netdev"}) }
       it { expect(cfg_file).to match(%r{DEVICETYPE=ovs}) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }  #  no more lines in the interface file
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }  #  no more lines in the interface file
 
     end
 
@@ -88,6 +90,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_centos7) do
       it { expect(res[:method].to_s).to eq 'manual' }
       it { expect(res[:mtu]).to eq '9000' }
       it { expect(res[:onboot]).to eq true }
+      it { expect(res[:datapath_type].to_s).to eq 'netdev' }
       it { expect(res[:provider]).to eq :ovs_centos7 }
     end
 

--- a/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/ovs_ubuntu__bridge__spec.rb
@@ -13,6 +13,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
         :onboot         => true,
         :method         => 'manual',
         :provider       => "ovs_ubuntu",
+        :datapath_type  => "netdev",
       },
     }
   end
@@ -75,7 +76,8 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(cfg_file).to match(/iface\s+br9\s+inet\s+manual/) }
       it { expect(cfg_file).to match(/ovs_type\s+OVSBridge/) }
       it { expect(cfg_file).to match(/mtu\s+9000/) }
-      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(5) }  #  no more lines in the interface file
+      it { expect(cfg_file).to match(/ovs_extra\s+set\s+Bridge\s+br9\s+datapath_type=netdev/) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(6) }  #  no more lines in the interface file
     end
 
     context "parse data from fixture" do
@@ -85,6 +87,7 @@ describe Puppet::Type.type(:l23_stored_config).provider(:ovs_ubuntu) do
       it { expect(res[:mtu]).to eq '9000' }
       it { expect(res[:if_type].to_s).to eq 'bridge' }
       it { expect(res[:if_provider].to_s).to eq 'ovs' }
+      it { expect(res[:datapath_type].to_s).to eq 'netdev' }
     end
 
   end

--- a/spec/unit/puppet/provider/l2_base_spec.rb
+++ b/spec/unit/puppet/provider/l2_base_spec.rb
@@ -236,6 +236,7 @@ type                : patch
                 :provider=>"ovs",
                 :stp=>false,
                 :vendor_specific=>{
+                    :datapath_type=>"",
                     :external_ids=>{:"bridge-id"=>"br-prv"},
                     :other_config=>{}, :status=>{}
                 }
@@ -246,6 +247,7 @@ type                : patch
                 :provider=>"ovs",
                 :stp=>false,
                 :vendor_specific=>{
+                    :datapath_type=>"",
                     :external_ids=>{},
                     :other_config=>{},
                     :status=>{}

--- a/spec/unit/puppet/provider/l2_bridge/ovs_spec.rb
+++ b/spec/unit/puppet/provider/l2_bridge/ovs_spec.rb
@@ -126,8 +126,21 @@ describe provider_class do
                 :provider => "ovs",
                 :stp => false,
                 :vendor_specific => {
+                    :datapath_type=>"",
                     :external_ids => {
                         :"bridge-id" => "br-prv"
+                    },
+                    :other_config => {},
+                    :status => {}}},
+            "br-dpdk" => {
+                :port_type => ["bridge"],
+                :br_type => "ovs",
+                :provider => "ovs",
+                :stp => false,
+                :vendor_specific => {
+                    :datapath_type=>"netdev",
+                    :external_ids => {
+                        :"bridge-id" => "br-dpdk"
                     },
                     :other_config => {},
                     :status => {}}},
@@ -137,6 +150,7 @@ describe provider_class do
                 :provider => "ovs",
                 :stp => false,
                 :vendor_specific => {
+                    :datapath_type=>"",
                     :external_ids => {},
                     :other_config => {},
                     :status => {}
@@ -153,6 +167,7 @@ describe provider_class do
               :ensure=>:present,
               :name=>"br-prv",
               :vendor_specific=>{
+                  :datapath_type=>"",
                   :external_ids=>{
                       :"bridge-id"=>"br-prv"
                   },
@@ -166,8 +181,25 @@ describe provider_class do
           },
           {
               :ensure=>:present,
+              :name=>"br-dpdk",
+              :vendor_specific=>{
+                  :datapath_type=>"netdev",
+                  :external_ids=>{
+                      :"bridge-id"=>"br-dpdk"
+                  },
+                  :other_config=>{},
+                  :status=>{}
+              },
+              :port_type=>"ovs:bridge",
+              :br_type=>"ovs",
+              :provider=>"ovs",
+              :stp=>false
+          },
+          {
+              :ensure=>:present,
               :name=>"br-int",
               :vendor_specific=>{
+                  :datapath_type=>"",
                   :external_ids=>{},
                   :other_config=>{},
                   :status=>{}
@@ -192,7 +224,7 @@ describe provider_class do
     provider_class.stubs(:ovs_vsctl_show).returns ovs_vsctl_show
     instances = provider_class.instances
     expect(instances).to be_a Array
-    expect(instances.length).to eq 2
+    expect(instances.length).to eq 3
     instances.each do |provider|
       expect(provider).to be_a Puppet::Type::L2_bridge::ProviderOvs
       class << provider


### PR DESCRIPTION
Introduce vendor_specific attribute datapath_type for ovs bridge. It
allows to create dpdk-enabled bridge.

FUEL-Change-Id: I6f3dbaeeef0d2ce6cb25dafeea79ae27eeb37e16
FUEL-Implements: blueprint support-dpdk

Closes: #238