### PR TITLE
Added dpdkovs provider for port

### DIFF
--- a/lib/puppet/provider/l23_stored_config/dpdkovs_centos7.rb
+++ b/lib/puppet/provider/l23_stored_config/dpdkovs_centos7.rb
@@ -1,0 +1,16 @@
+require 'puppetx/filemapper'
+require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_dpdkovs_centos')
+
+Puppet::Type.type(:l23_stored_config).provide(:dpdkovs_centos7, :parent => Puppet::Provider::L23_stored_config_dpdkovs_centos) do
+
+  include PuppetX::FileMapper
+
+  confine    :l23_os => :centos7
+
+  has_feature :provider_options
+
+  self.unlink_empty_files = true
+
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l23_stored_config/dpdkovs_ubuntu.rb
+++ b/lib/puppet/provider/l23_stored_config/dpdkovs_ubuntu.rb
@@ -1,0 +1,65 @@
+require 'puppetx/filemapper'
+require 'puppetx/l23_dpdk_ports_mapping'
+require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_ubuntu')
+
+Puppet::Type.type(:l23_stored_config).provide(:dpdkovs_ubuntu, :parent => Puppet::Provider::L23_stored_config_ubuntu) do
+
+  include PuppetX::FileMapper
+
+  confine    :l23_os => :ubuntu
+
+  has_feature :provider_options
+
+  self.unlink_empty_files = true
+
+  def self.get_dpdk_ports_mapping
+    L23network.get_dpdk_ports_mapping
+  end
+
+  def self.check_if_provider(if_data)
+    if if_data[:if_type] =~ /dpdkovsport/
+        if_data[:if_type] = "ethernet"
+        if_data[:if_provider] = :dpdkovs
+        true
+    else
+        if_data[:if_provider] = nil
+        false
+    end
+  end
+
+  def self.property_mappings
+    rv = super
+    rv.merge!({
+      :if_type        => 'ovs_type',
+      :bridge         => 'ovs_bridge',
+      :dpdk_port      => 'dpdk_port',
+    })
+    return rv
+  end
+
+  def self.iface_file_header(provider)
+    header = []
+    props  = {}
+
+    ports = self.get_dpdk_ports_mapping()
+    dpdk_port = ports.map { |i,p| i if p[:interface] == provider.name}.compact[0]
+
+    bridge = provider.bridge[0]
+    props[:bridge] = bridge
+    props[:dpdk_port] = dpdk_port
+
+    header << self.puppet_header
+    header << "allow-#{bridge} #{provider.name}"
+    header << "iface #{provider.name} inet #{provider.method}"
+    header << "pre-up ovs-vsctl --may-exist add-port ${IF_OVS_BRIDGE} ${IF_DPDK_PORT} -- ${IF_OVS_EXTRA}"
+    header << "ovs_extra set Interface #{dpdk_port} type=dpdk"
+    return header, props
+  end
+
+  def self.unmangle__if_type(provider, val)
+    val = 'DPDKOVSPort' if val.to_s == 'ethernet'
+    val
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l23_stored_config_dpdkovs_centos.rb
+++ b/lib/puppet/provider/l23_stored_config_dpdkovs_centos.rb
@@ -1,0 +1,26 @@
+require 'puppetx/l23_dpdk_ports_mapping'
+require File.join(File.dirname(__FILE__), '..','..','puppet/provider/l23_stored_config_centos')
+
+class Puppet::Provider::L23_stored_config_dpdkovs_centos < Puppet::Provider::L23_stored_config_centos
+
+  def self.get_dpdk_ports_mapping
+    L23network.get_dpdk_ports_mapping
+  end
+
+  def self.property_mappings
+    rv = super
+    rv.merge!({
+      :devicetype => 'DEVICETYPE',
+      :bridge     => 'OVS_BRIDGE',
+      :dpdk_port  => 'DPDK_PORT',
+    })
+    return rv
+  end
+
+  def self.unmangle__if_type(provider, val)
+    val = 'DPDKOVSPort' if val.to_s == 'ethernet'
+    val
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l2_bridge/ovs.rb
+++ b/lib/puppet/provider/l2_bridge/ovs.rb
@@ -53,8 +53,8 @@ Puppet::Type.type(:l2_bridge).provide(:ovs, :parent => Puppet::Provider::Ovs_bas
         end
       end
       vs = (@property_flush[:vendor_specific] || {})
-      if vs.has_key? :datapath_type
-        vsctl('set', 'Bridge', @resource[:bridge], "datapath_type=#{vs[:datapath_type]}")
+      if vs.has_key? "datapath_type"
+        vsctl('set', 'Bridge', @resource[:bridge], "datapath_type=#{vs["datapath_type"]}")
       end
       #
       @property_hash = resource.to_hash

--- a/lib/puppet/provider/l2_port/dpdkovs.rb
+++ b/lib/puppet/provider/l2_port/dpdkovs.rb
@@ -1,0 +1,54 @@
+require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/ovs_base')
+require 'puppetx/l23_dpdk_ports_mapping'
+
+Puppet::Type.type(:l2_port).provide(:dpdkovs, :parent => Puppet::Provider::Ovs_base) do
+  commands   :vsctl       => 'ovs-vsctl',
+             :ethtool_cmd => 'ethtool'
+
+  def self.get_dpdk_ports_mapping
+    L23network.get_dpdk_ports_mapping
+  end
+
+  def self.get_instances(big_hash)
+    dpdk_ports_mapping = get_dpdk_ports_mapping()
+    ports = big_hash.fetch(:port, {}).map do |p_name, p_info|
+      dpdk_info = dpdk_ports_mapping[p_name.to_s]
+      p_info.merge!(dpdk_info) if dpdk_info
+      [p_info[:interface] || p_name, p_info]
+    end
+    Hash[ports].select {|k,v| v[:type].to_s == 'dpdk'}
+  end
+
+  def create
+    debug("CREATE resource: #{@resource}")
+    @old_property_hash = {}
+    @property_flush = {}.merge! @resource
+
+    ports = self.class.get_dpdk_ports_mapping()
+    dpdk_prop = ports.map { |i,p| p if p[:interface] == @resource[:interface]}.compact[0]
+    raise Puppet::ExecutionFailure, "Can't add port '#{@resource[:interface]}'\n#{error}" unless dpdk_prop
+    @property_flush.merge! dpdk_prop
+
+    cmd = ['--may-exist', 'add-port', @resource[:bridge], @property_flush[:vendor_specific]['dpdk_port']]
+    tt = "type=" + @property_flush[:type].to_s
+    cmd += ['--', "set", "Interface", @property_flush[:vendor_specific]['dpdk_port'], tt] if tt
+
+    begin
+      vsctl(cmd)
+    rescue Puppet::ExecutionFailure => error
+      raise Puppet::ExecutionFailure, "Can't add port '#{@resource[:interface]}'\n#{error}"
+    end
+  end
+
+  def destroy
+    vsctl("del-port", @resource[:bridge], @resource[:vendor_specific]['dpdk_port'])
+  end
+
+  def flush
+    if ! @property_flush.empty?
+      debug("FLUSH properties: #{@property_flush}")
+      @property_hash = resource.to_hash
+    end
+  end
+end
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/type/l2_port.rb
+++ b/lib/puppet/type/l2_port.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:l2_port) do
 
     #todo(sv): move to provider_specific hash
     newproperty(:type) do
-      newvalues(:system, :internal, :tap, :gre, :ipsec_gre, :capwap, :patch, :null, :undef, :nil, :none)
+      newvalues(:system, :internal, :tap, :gre, :ipsec_gre, :capwap, :patch, :dpdk, :null, :undef, :nil, :none)
       aliasvalue(:none,  :internal)
       aliasvalue(:undef, :internal)
       aliasvalue(:nil,   :internal)

--- a/lib/puppetx/l23_dpdk_ports_mapping.rb
+++ b/lib/puppetx/l23_dpdk_ports_mapping.rb
@@ -1,0 +1,61 @@
+require 'puppetx/l23_network_scheme'
+
+module L23network
+  def self.get_dpdk_ports_mapping()
+    # returns hash, which map dpdk ports to real ports
+    # i.e {
+    #       'dpdk0'    => { # generated name
+    #         :interface => "enp1s0f0", # real name
+    #         :port_type => [],
+    #         :type => "dpdk",
+    #         :provider => "dpdkovs",
+    #         :vendor_specific => {
+    #           "dpdk_driver" => "igb_uio"
+    #           "dpdk_port" => "dpdk0"
+    #         }
+    #       }
+    #     }
+    # This function scans PCI for ethernet devices, and filters only those
+    # that bounded to dpdk drivers (it works exactly as dpdk_nic_bind --status).
+    # Then devices mapped to network scheme via bus_info to retrieve original
+    # names. DPDK devices is sorted by bus_info and numbered from 0.
+    #
+    # dpdk_drivers contains list of dpdk drivers
+    #
+
+    dpdk_drivers = %w[ igb_uio vfio-pci uio_pci_generic ]
+    ethernet_class = 0x020000
+
+    cfg = L23network::Scheme.get_config(Facter.value(:l3_fqdn_hostname))
+    return {} unless cfg
+
+    interfaces = cfg[:interfaces].map { |i,p| [p[:vendor_specific][:bus_info], i] if p.has_key?(:vendor_specific) }
+    bus_info_map = Hash[interfaces.compact]
+
+    devices = Dir['/sys/bus/pci/devices/*/class'].map do |class_file|
+      next unless File.read(class_file).to_i(16) == ethernet_class
+      dev_dir = File.dirname(class_file)
+      bus_info = File.basename(dev_dir)
+      next unless File.exists?("#{dev_dir}/driver")
+      driver = File.basename(File.readlink("#{dev_dir}/driver"))
+      next unless dpdk_drivers.include? driver
+      next unless bus_info_map.has_key? bus_info
+      {
+        :interface    => bus_info_map[bus_info].to_s,
+        :port_type    => [],
+        :type         => 'dpdk',
+        :provider     => 'dpdkovs',
+        :vendor_specific => {
+          'dpdk_driver' => driver
+        }
+      }
+    end
+    dpdk_devices = devices.compact.each_with_index.map do |port_info,i|
+      dpdk_port = "dpdk#{i}"
+      port_info[:vendor_specific]['dpdk_port'] = dpdk_port
+      [dpdk_port, port_info]
+    end
+    Hash[dpdk_devices]
+  end
+
+end

--- a/lib/puppetx/l23_network_scheme.rb
+++ b/lib/puppetx/l23_network_scheme.rb
@@ -5,6 +5,7 @@ module L23network
       @network_scheme_hash[h.to_sym] = v
     end
     def self.get_config(h)
+      @network_scheme_hash ||= {}
       @network_scheme_hash[h.to_sym]
     end
     def self.has_config?

--- a/spec/fixtures/provider/l23_stored_config/dpdkovs_ubuntu__spec/ifcfg-enp1s0f0
+++ b/spec/fixtures/provider/l23_stored_config/dpdkovs_ubuntu__spec/ifcfg-enp1s0f0
@@ -1,0 +1,7 @@
+allow-br-prv enp1s0f0
+iface enp1s0f0 inet manual
+pre-up ovs-vsctl --may-exist add-port "${IF_OVS_BRIDGE}" "${IF_DPDK_PORT}" -- ${IF_OVS_EXTRA}
+ovs_extra set Interface dpdk0 type=dpdk
+ovs_type DPDKOVSPort
+dpdk_port dpdk0
+ovs_bridge br-prv

--- a/spec/unit/puppet/provider/l23_stored_config/dpdkovs_ubuntu__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/dpdkovs_ubuntu__port__spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l23_stored_config).provider(:dpdkovs_ubuntu) do
+  let(:input_data) {
+    {
+      :'enp1s0f0' => {
+                 :name     => 'enp1s0f0',
+                 :if_type  => 'ethernet',
+                 :bridge   => 'br-prv',
+                 :provider => 'dpdkovs_ubuntu',
+               },
+    }
+  }
+
+  let(:dpdk_ports_mapping) {
+    {
+      'dpdk0'    => {
+        :interface => 'enp1s0f0',
+        :port_type => [],
+        :type => "dpdk",
+        :provider => "dpdkovs",
+        :vendor_specific => {
+          "dpdk_driver" => "igb_uio",
+          "dpdk_port" => "dpdk0"
+        }
+      }
+    }
+  }
+
+  let(:resources) do
+    resources = {}
+    input_data.each do |name, res|
+      resources.store name, Puppet::Type.type(:l23_stored_config).new(res)
+    end
+    return resources
+  end
+
+  let(:providers) do
+    providers = {}
+    resources.each do |name, resource|
+      provider = resource.provider
+      if ENV['SPEC_PUPPET_DEBUG']
+        class << provider
+          def debug(msg)
+            puts msg
+          end
+        end
+      end
+      provider.create
+      providers.store name, provider
+    end
+    return providers
+  end
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  def fixture_path
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'l23_stored_config', 'dpdkovs_ubuntu__spec')
+  end
+
+  def fixture_file(file)
+    File.join(fixture_path, file)
+  end
+
+  def fixture_data(file)
+     File.read(fixture_file(file))
+  end
+
+  context "formating config files" do
+    context 'DPDKOVS port enp1s0f0' do
+      subject { providers[:enp1s0f0] }
+      let(:cfg_file) do
+        subject.class.stubs(:get_dpdk_ports_mapping).returns(dpdk_ports_mapping)
+        subject.class.format_file('filepath', [subject])
+      end
+      it { expect(cfg_file).to match(/allow-br-prv\s+enp1s0f0/) }
+      it { expect(cfg_file).to match(/iface\s+enp1s0f0\s+inet\s+manual/) }
+      it { expect(cfg_file).to match(/ovs_type\s+DPDKOVSPort/) }
+      it { expect(cfg_file).to match(/ovs_bridge\s+br-prv/) }
+      it { expect(cfg_file).to match(/dpdk_port\s+dpdk0/) }
+      it { expect(cfg_file).to match(/ovs_extra\s+set\s+Interface\s+dpdk0\s+type=dpdk/) }
+      it { expect(cfg_file.split(/\n/).reject{|x| x=~/(^\s*$)|(^#.*$)/}.length). to eq(7) }
+    end
+  end
+
+  context "parsing config files" do
+    context 'OVS port enp1s0f0' do
+      let(:res) { subject.class.parse_file('enp1s0f0', fixture_data('ifcfg-enp1s0f0'))[0] }
+      it { expect(res[:method]).to eq :manual }
+      it { expect(res[:name]).to eq 'enp1s0f0' }
+      it { expect(res[:bridge]).to eq "br-prv" }
+      it { expect(res[:if_provider].to_s).to eq 'dpdkovs' }
+      it { expect(res[:dpdk_port].to_s).to eq 'dpdk0' }
+    end
+  end
+end

--- a/spec/unit/puppet/provider/l2_port/dpdkovs__spec.rb
+++ b/spec/unit/puppet/provider/l2_port/dpdkovs__spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:l2_port).provider(:dpdkovs) do
+  let(:resource_br1) {
+    Puppet::Type.type(:l2_bridge).new(
+      :provider => 'ovs',
+      :name     => 'br1',
+      :bridge   => 'br1',
+      :vendor_specific => {
+          :datapath_type => 'netdev',
+      }
+    )
+  }
+  let(:provider_br1) { resource_br1.provider }
+
+  let(:resource_port) {
+    Puppet::Type.type(:l2_port).new(
+      :provider => 'dpdkovs',
+      :bridge   => 'br1',
+      :name     => 'eth0',
+    )
+  }
+  let(:provider_port) { resource_port.provider }
+
+  let(:dpdk_ports_mapping) {
+    {
+      'dpdk0'    => {
+        :interface => "eth0",
+        :port_type => [],
+        :type => "dpdk",
+        :provider => "dpdkovs",
+        :vendor_specific => {
+          "dpdk_driver" => "igb_uio",
+          "dpdk_port" => "dpdk0"
+        }
+      }
+    }
+  }
+
+  describe "ovs port" do
+    before(:each) do
+      puppet_debug_override()
+      provider_br1.class.stubs(:vsctl).with('add-br', 'br1').returns(true)
+      provider_br1.class.stubs(:vsctl).with('set', 'Bridge', 'br1', 'stp_enable=false').returns(true)
+      provider_br1.class.stubs(:vsctl).with('set', 'Bridge', 'br1', 'datapath_type=netdev').returns(true)
+      provider_br1.class.stubs(:interface_up).with('br1').returns(true)
+    end
+
+    it "Create bridge and add physical port to it" do
+      provider_br1.create
+      provider_br1.flush
+      provider_port.class.stubs(:vsctl).with(['--may-exist', 'add-port', 'br1', 'dpdk0', '--', 'set', 'Interface', 'dpdk0', 'type=dpdk']).returns(true)
+      provider_port.class.stubs(:get_dpdk_ports_mapping).returns(dpdk_ports_mapping)
+      provider_port.create
+    end
+  end
+end


### PR DESCRIPTION
New provider `dpdkovs` introduced for add-port action. It discovers DPDK
interface by system name using L23network.get_dpdk_ports_mapping,
connects port to OpenVSwitch, and store in to network configuration.

Ethernet to DPDK conversion will be done near dpdk + ovs configuration
in next patch.

L23network.get_dpdk_ports_mapping is based on bus_info from interfaces hash.

Centos part will be done in next patch.

FUEL-Change-Id: I0c64914a8a29eb597948511008f778c507517849
FUEL-Implements: blueprint support-dpdk

Closes: #246