### PR TITLE
llow to process empty string as nil

### DIFF
--- a/lib/puppet/parser/functions/get_default_gateways.rb
+++ b/lib/puppet/parser/functions/get_default_gateways.rb
@@ -31,7 +31,7 @@ Puppet::Parser::Functions::newfunction(:get_default_gateways, :type => :rvalue, 
 
   rv = []
   endpoints.each do |ep_name, ep_props|
-    next if ep_props[:gateway].nil?
+    next if ep_props[:gateway].to_s == ''
     rv << {
       :m  => (ep_props[:gateway_metric] or 0),
       :g => ep_props[:gateway]


### PR DESCRIPTION
Assign empty string to gateway is a unical method for override
such value from plugin by hiera override.

FUEL-Change-Id: I998fdd4d443c84bf8b96a6e987ff9f0cb1f969d5
FUEL-Closes-bug: #1549550

Closes: #250