### PR TITLE
dpdk_driver moved to interfaces

### DIFF
--- a/lib/puppet/parser/functions/get_dpdk_interfaces.rb
+++ b/lib/puppet/parser/functions/get_dpdk_interfaces.rb
@@ -1,28 +1,21 @@
 require 'puppetx/l23_network_scheme'
 
 Puppet::Parser::Functions::newfunction(:get_dpdk_interfaces, :type => :rvalue, :doc => <<-EOS
-    This function gets list of interfaces and port transformations and
-    returns bus_info addresses and intended drivers for dpdk transformations.
+    This function gets list of interfaces and returns bus_info addresses and
+    intended drivers for dpdk transformations.
     ex: get_dpdk_interfaces() => [["0000:01:00.0", "igb_uio"]]
     EOS
   ) do |args|
-  dpdk_interfaces = {}
-
   cfg = L23network::Scheme.get_config(lookupvar('l3_fqdn_hostname'))
   return [] unless cfg
 
-  interfaces = cfg[:interfaces]
-  cfg[:transformations].each do |transform|
-    next unless transform[:name] ||\
-         transform[:provider].to_s.upcase == "DPDKOVS" ||\
-         transform[:action] == "add-port"
-
-    if_name = transform[:name].to_sym
-    bus_info = interfaces[if_name][:vendor_specific][:bus_info] if interfaces.has_key?(if_name)
-    dpdk_driver = transform[:vendor_specific][:dpdk_driver] if transform[:vendor_specific]
-    dpdk_interfaces[bus_info] = dpdk_driver if bus_info and dpdk_driver
+  dpdk_interfaces = {}
+  cfg[:interfaces].each do |if_name, if_data|
+    vendor_specific = if_data[:vendor_specific] || {}
+    bus_info = vendor_specific[:bus_info]
+    dpdk_driver = vendor_specific[:dpdk_driver]
+    dpdk_interfaces[bus_info] = dpdk_driver if bus_info && dpdk_driver
   end
-
   dpdk_interfaces.sort
 end
 

--- a/lib/puppetx/l23_dpdk_ports_mapping.rb
+++ b/lib/puppetx/l23_dpdk_ports_mapping.rb
@@ -10,7 +10,6 @@ module L23network
     #         :type => "dpdk",
     #         :provider => "dpdkovs",
     #         :vendor_specific => {
-    #           "dpdk_driver" => "igb_uio"
     #           "dpdk_port" => "dpdk0"
     #         }
     #       }
@@ -45,9 +44,7 @@ module L23network
         :port_type    => [],
         :type         => 'dpdk',
         :provider     => 'dpdkovs',
-        :vendor_specific => {
-          'dpdk_driver' => driver
-        }
+        :vendor_specific => {}
       }
     end
     dpdk_devices = devices.compact.each_with_index.map do |port_info,i|

--- a/spec/functions/get_dpdk_interfaces__spec.rb
+++ b/spec/functions/get_dpdk_interfaces__spec.rb
@@ -17,21 +17,16 @@ let(:network_scheme) do
       vendor_specific:
         driver: ixgbe
         bus_info: "0000:01:00.1"
+        dpdk_driver: igb_uio
     enp1s0f0:
       vendor_specific:
         driver: ixgbe
         bus_info: "0000:01:00.0"
+        dpdk_driver: igb_uio
     eno1:
       vendor_specific:
         driver: tg3
         bus_info: "0000:02:00.1"
-  transformations:
-    - bridge: br-prv
-      name: enp1s0f0
-      action: add-port
-      provider: dpdkovs
-      vendor_specific:
-        dpdk_driver: igb_uio
 eof
 end
 
@@ -56,7 +51,7 @@ end
     end
 
     it 'should return dpdk driver list' do
-      should run.with_params().and_return([["0000:01:00.0", "igb_uio"]])
+      should run.with_params().and_return([["0000:01:00.0", "igb_uio"], ["0000:01:00.1", "igb_uio"]])
     end
   end
 end

--- a/spec/unit/puppet/provider/l23_stored_config/dpdkovs_ubuntu__port__spec.rb
+++ b/spec/unit/puppet/provider/l23_stored_config/dpdkovs_ubuntu__port__spec.rb
@@ -20,7 +20,6 @@ describe Puppet::Type.type(:l23_stored_config).provider(:dpdkovs_ubuntu) do
         :type => "dpdk",
         :provider => "dpdkovs",
         :vendor_specific => {
-          "dpdk_driver" => "igb_uio",
           "dpdk_port" => "dpdk0"
         }
       }

--- a/spec/unit/puppet/provider/l2_port/dpdkovs__spec.rb
+++ b/spec/unit/puppet/provider/l2_port/dpdkovs__spec.rb
@@ -30,7 +30,6 @@ describe Puppet::Type.type(:l2_port).provider(:dpdkovs) do
         :type => "dpdk",
         :provider => "dpdkovs",
         :vendor_specific => {
-          "dpdk_driver" => "igb_uio",
           "dpdk_port" => "dpdk0"
         }
       }


### PR DESCRIPTION
dpdk_driver was moved from transformation to network_scheme interfaces
to address spec change to enable OVS-DPDK bond.

Implements: blueprint support-dpdk
Partially implements: blueprint support-dpdk-bond
FUEL-Depends-On: I29a9f3403edf4c64b3257e3f6265fee1abffe01b
FUEL-Change-Id: Ie6d31da1f096a2fd6791d1b22f92417d9fd027eb

Closes: #254