### PR TITLE
Add workaround for import puppetx::* from parser functions

### DIFF
--- a/lib/puppet/parser/functions/generate_network_config.rb
+++ b/lib/puppet/parser/functions/generate_network_config.rb
@@ -5,10 +5,18 @@ require 'puppet/parser'
 require 'puppet/parser/templatewrapper'
 require 'puppet/resource/type_collection_helper'
 require 'puppet/util/methodhelper'
-require 'puppetx/l23_utils'
-require 'puppetx/l23_network_scheme'
-
-
+begin
+  require 'puppetx/l23_utils'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_utils.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 
 module L23network
   def self.default_offload_set

--- a/lib/puppet/parser/functions/get_default_gateways.rb
+++ b/lib/puppet/parser/functions/get_default_gateways.rb
@@ -8,7 +8,12 @@ rescue LoadError => e
   rb_file = File.join(File.dirname(__FILE__),'lib','prepare_cidr.rb')
   load rb_file if File.exists?(rb_file) or raise e
 end
-require 'puppetx/l23_network_scheme'
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 
 Puppet::Parser::Functions::newfunction(:get_default_gateways, :type => :rvalue, :doc => <<-EOS
     Parse network_scheme and return list of default gateways,

--- a/lib/puppet/parser/functions/get_network_role_property.rb
+++ b/lib/puppet/parser/functions/get_network_role_property.rb
@@ -8,8 +8,12 @@ rescue LoadError => e
   rb_file = File.join(File.dirname(__FILE__),'lib','prepare_cidr.rb')
   load rb_file if File.exists?(rb_file) or raise e
 end
-require 'puppetx/l23_network_scheme'
-
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 Puppet::Parser::Functions::newfunction(:get_network_role_property, :type => :rvalue, :doc => <<-EOS
     This function get get network the network_role name and mode --
     and return information about network role.

--- a/lib/puppet/parser/functions/get_pair_of_jack_names.rb
+++ b/lib/puppet/parser/functions/get_pair_of_jack_names.rb
@@ -1,4 +1,9 @@
-require 'puppetx/l23_utils'
+begin
+  require 'puppetx/l23_utils'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_utils.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 #
 module Puppet::Parser::Functions
   newfunction(:get_pair_of_jack_names, :type => :rvalue) do |arguments|

--- a/lib/puppet/parser/functions/get_patch_name.rb
+++ b/lib/puppet/parser/functions/get_patch_name.rb
@@ -1,4 +1,9 @@
-require 'puppetx/l23_utils'
+begin
+  require 'puppetx/l23_utils'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_utils.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 #
 module Puppet::Parser::Functions
   newfunction(:get_patch_name, :type => :rvalue) do |arguments|

--- a/lib/puppet/parser/functions/get_route_resource_name.rb
+++ b/lib/puppet/parser/functions/get_route_resource_name.rb
@@ -1,4 +1,9 @@
-require 'puppetx/l23_utils'
+begin
+  require 'puppetx/l23_utils'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_utils.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 #
 module Puppet::Parser::Functions
   newfunction(:get_route_resource_name, :type => :rvalue) do |argv|

--- a/lib/puppet/parser/functions/get_transformation_property.rb
+++ b/lib/puppet/parser/functions/get_transformation_property.rb
@@ -1,4 +1,9 @@
-require 'puppetx/l23_network_scheme'
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 
 Puppet::Parser::Functions::newfunction(:get_transformation_property, :type => :rvalue, :doc => <<-EOS
     This function gets an properties from transformations

--- a/lib/puppet/parser/functions/prepare_network_config.rb
+++ b/lib/puppet/parser/functions/prepare_network_config.rb
@@ -1,5 +1,15 @@
-require 'puppetx/l23_network_scheme'
-require 'puppetx/l23_hash_tools'
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
+begin
+  require 'puppetx/l23_hash_tools'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_hash_tools.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 
 module Puppet::Parser::Functions
   newfunction(:prepare_network_config, :doc => <<-EOS

--- a/lib/puppet/parser/functions/sanitize_bool_in_hash.rb
+++ b/lib/puppet/parser/functions/sanitize_bool_in_hash.rb
@@ -1,4 +1,9 @@
-require 'puppetx/l23_hash_tools'
+begin
+  require 'puppetx/l23_hash_tools'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_hash_tools.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 
 module Puppet::Parser::Functions
   newfunction(:sanitize_bool_in_hash, :type => :rvalue, :doc => <<-EOS


### PR DESCRIPTION
in the Puppet-master mode.

FUEL-Change-Id: I5a5cda8cb6a5e1814637574f36e2e001d2b551d1
FUEL-Closes-Bug: #1544040

Closes: #256