### PR TITLE
Add support for OracleLinux (RedHat family)

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,15 @@ version, and the specific network provider (native linux, ovs, etc...)
 
 
 
+## Supported operating systems
+
+  * CentOS 6 and 7
+  * RedHat 7
+  * OracleLinux 7
+  * Ubuntu
+
+
+
 ## References
 
   * [Transformations. How they work.](https://docs.google.com/document/d/12RvBjOYO83_yqeiAgxttrRaa90-8un80aEO8OzDlQ9Y)

--- a/lib/facter/l23_os.rb
+++ b/lib/facter/l23_os.rb
@@ -20,6 +20,11 @@ Facter.add(:l23_os) do
           when /7/
             'redhat7'
         end
+      when /(?i)oraclelinux/
+        case Facter.value(:operatingsystemmajrelease)
+          when /7/
+            'oraclelinux7'
+        end
       when /(?i)darwin/
         'osx'
     end

--- a/lib/puppet/provider/l23_stored_config/lnx_oraclelinux7.rb
+++ b/lib/puppet/provider/l23_stored_config/lnx_oraclelinux7.rb
@@ -1,0 +1,16 @@
+require 'puppetx/filemapper'
+require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_centos')
+
+Puppet::Type.type(:l23_stored_config).provide(:lnx_oraclelinux7, :parent => Puppet::Provider::L23_stored_config_centos) do
+
+  include PuppetX::FileMapper
+
+  confine    :l23_os => :oraclelinux7
+  defaultfor :l23_os => :oraclelinux7
+
+  has_feature :provider_options
+
+  self.unlink_empty_files = true
+
+end
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l23_stored_config/ovs_oraclelinux7.rb
+++ b/lib/puppet/provider/l23_stored_config/ovs_oraclelinux7.rb
@@ -1,0 +1,16 @@
+require 'puppetx/filemapper'
+require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_ovs_centos')
+
+Puppet::Type.type(:l23_stored_config).provide(:ovs_oraclelinux7, :parent => Puppet::Provider::L23_stored_config_ovs_centos) do
+
+  include PuppetX::FileMapper
+
+  confine    :l23_os => :oraclelinux7
+
+  has_feature :provider_options
+
+  self.unlink_empty_files = true
+
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/provider/l23_stored_config/sriov_oraclelinux7.rb
+++ b/lib/puppet/provider/l23_stored_config/sriov_oraclelinux7.rb
@@ -1,0 +1,16 @@
+require 'puppetx/filemapper'
+require File.join(File.dirname(__FILE__), '..','..','..','puppet/provider/l23_stored_config_sriov_centos')
+
+Puppet::Type.type(:l23_stored_config).provide(:sriov_oraclelinux7, :parent => Puppet::Provider::L23_stored_config_sriov_centos) do
+
+  include PuppetX::FileMapper
+
+  confine    :l23_os => :oraclelinux7
+
+  has_feature :provider_options
+
+  self.unlink_empty_files = true
+
+end
+
+# vim: set ts=2 sw=2 et :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class l23network (
   Anchor['l23network::l2::init'] -> File<| title == $::l23network::params::interfaces_file |>
 
   # Centos interface up-n-down scripts
-  if $::l23_os =~ /(?i:redhat|centos)/ {
+  if $::l23_os =~ /(?i:redhat|centos|oraclelinux)/ {
     class{'::l23network::l2::centos_upndown_scripts': } -> Anchor['l23network::init']
     Anchor <| title == 'l23network::l2::centos_upndown_scripts' |> -> Anchor['l23network::init']
   }
@@ -133,7 +133,7 @@ class l23network (
     # It is not enough to just remove package, we have to stop the service as well.
     # Because SystemD continues running the service after package removing,
     # with Upstart - all is ok.
-    if $::l23_os =~ /(?i)redhat7|centos7/ {
+    if $::l23_os =~ /(?i)redhat7|centos7|oraclelinux7/ {
       service{$::l23network::params::network_manager_name:
         ensure => 'stopped',
       }

--- a/manifests/l2/bond.pp
+++ b/manifests/l2/bond.pp
@@ -264,7 +264,7 @@ define l23network::l2::bond (
 
   }
 
-  if $::l23_os =~ /(?i:redhat|centos)/ {
+  if $::l23_os =~ /(?i:redhat|centos|oraclelinux)/ {
     if $delay_while_up {
       file {"${::l23network::params::interfaces_dir}/interface-up-script-${bond}":
         ensure  => present,

--- a/manifests/l2/bridge.pp
+++ b/manifests/l2/bridge.pp
@@ -69,7 +69,7 @@ define l23network::l2::bridge (
     Anchor['l23network::init'] -> K_mod<||> -> L2_bridge<||>
   }
 
-  if $::l23_os =~ /(?i:redhat|centos)/ {
+  if $::l23_os =~ /(?i:redhat|centos|oraclelinux)/ {
     if $delay_while_up {
       file {"${::l23network::params::interfaces_dir}/interface-up-script-${name}":
         ensure  => present,

--- a/manifests/l2/port.pp
+++ b/manifests/l2/port.pp
@@ -169,7 +169,7 @@ define l23network::l2::port (
     Anchor['l23network::init'] -> K_mod<||> -> L2_port<||>
   }
 
-  if $::l23_os =~ /(?i:redhat|centos)/ {
+  if $::l23_os =~ /(?i:redhat|centos|oraclelinux)/ {
     if $delay_while_up {
       file {"${::l23network::params::interfaces_dir}/interface-up-script-${port_name}":
         ensure  => present,

--- a/manifests/l3/defaultroute.pp
+++ b/manifests/l3/defaultroute.pp
@@ -18,7 +18,7 @@ define l23network::l3::defaultroute (
             unless  => "netstat -r | grep -q 'default.*${gateway}'",
         }
     }
-    /(?i:redhat|centos)/: {
+    /(?i:redhat|centos|oraclelinux)/: {
         Cfg <| name == $gateway |>
         if ! defined(Cfg[$gateway]) {
           cfg { $gateway:


### PR DESCRIPTION
Update l23network module to support OracleLinux.
Deployment cases are the same as for centos and redhat.

Additional changes:
  * remove installation of cpufreq-init package.
    It doesn't exist anymore for CentOS.
  * update README with list of supported OS

FUEL-Blueprint: oracle-linux-compute-nodes
FUEL-Change-Id: Icba00728422326361208cd5a40a753e0310409d3

Closes: #258