### PR TITLE
Bump puppet-lint version to 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development, :test do
   gem 'rspec', '~>3.3',          :require => false
   gem 'rspec-puppet', '~>2.2.0', :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet-lint', '~> 0.3.2'
+  gem 'puppet-lint', '~> 1.1'
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
 * Bump puppet-lint version to 1.1
 * Remove excessive spaces causing lint error messages

FUEL-Change-Id: I7ee922ea09d3dff520c8c80791cb54bdff9bc5fc
FUEL-Closes-bug: #1552183

Closes: #254