### PR TITLE
Change umask 0002 to 0000 for vhostuser sockets

### DIFF
--- a/manifests/l2/dpdk.pp
+++ b/manifests/l2/dpdk.pp
@@ -35,8 +35,6 @@ class l23network::l2::dpdk (
   $dpdk_dir                    = $::l23network::params::dpdk_dir,
   $dpdk_conf_file              = $::l23network::params::dpdk_conf_file,
   $dpdk_interfaces_file        = $::l23network::params::dpdk_interfaces_file,
-  $ovs_socket_dir_group        = $::l23network::params::ovs_socket_dir_group,
-  $ovs_socket_dir              = $::l23network::params::ovs_socket_dir,
   $ovs_default_file            = $::l23network::params::ovs_default_file,
   $install_ovs                 = true,
   $ensure_package              = 'present',

--- a/templates/openvswitch_default_Debian.erb
+++ b/templates/openvswitch_default_Debian.erb
@@ -1,13 +1,6 @@
 /etc/init.d/dpdk start
 
-export DPDK_OPTS="--dpdk <% if @ovs_socket_dir %>-vhost_sock_dir <%= @ovs_socket_dir %> <% end %>-c <%= @ovs_core_mask %> -n <%= @ovs_memory_channels %> --socket-mem <%= @ovs_socket_mem %>"
+export DPDK_OPTS="--dpdk -c <%= @ovs_core_mask %> -n <%= @ovs_memory_channels %> --socket-mem <%= @ovs_socket_mem %>"
 
-<% if @ovs_socket_dir -%>
 # LP 1546565
-umask 0002
-mkdir -p "<%= @ovs_socket_dir %>"
-<% if @ovs_socket_dir_group -%>
-chgrp "<%= @ovs_socket_dir_group %>" "<%= @ovs_socket_dir %>" || true
-<% end -%>
-chmod g+s "<%= @ovs_socket_dir %>"
-<% end -%>
+umask 0000


### PR DESCRIPTION
Due to unavailabitiy of libvirt-qemu group on netconfig time, it's
unable to set group correctly.

FUEL-Change-Id: I09d7e99dbf8d2678502069458c3066fd1ffaf3f3
FUEL-Closes-Bug: #1562985

Closes: #269