### PR TITLE
nherit provider for ports from bridges as default

### DIFF
--- a/lib/puppet/parser/functions/generate_network_config.rb
+++ b/lib/puppet/parser/functions/generate_network_config.rb
@@ -41,7 +41,7 @@ module L23network
     return rv
   end
 
-  def self.sanitize_transformation(trans, def_provider=nil)
+  def self.sanitize_transformation(trans)
     action = trans[:action].to_s.downcase()
     # Setup defaults
     rv = case action
@@ -58,7 +58,7 @@ module L23network
 #       :interface_properties => nil,
         :delay_while_up       => nil,
         :vendor_specific      => nil,
-        :provider             => def_provider
+        :provider             => nil
       }
       when "add-port" then {
         :name                 => nil,
@@ -71,7 +71,7 @@ module L23network
 #       :trunks               => [],
         :delay_while_up       => nil,
         :vendor_specific      => nil,
-        :provider             => def_provider
+        :provider             => nil
       }
       when "add-bond" then {
         :name                 => nil,
@@ -84,7 +84,7 @@ module L23network
         :bond_properties      => nil,
         :interface_properties => nil,
         :vendor_specific      => nil,
-        :provider             => def_provider
+        :provider             => nil
       }
       when "add-patch" then {
         :name            => "unnamed", # calculated later
@@ -92,7 +92,7 @@ module L23network
         :vlan_ids        => [0, 0],
         :mtu             => nil,
         :vendor_specific => nil,
-        :provider        => def_provider
+        :provider        => nil
       }
       else
         raise(Puppet::ParseError, "Unknown transformation: '#{action}'.")
@@ -356,7 +356,7 @@ Puppet::Parser::Functions::newfunction(:generate_network_config, :type => :rvalu
       if action != :noop
 
         #debug("TXX: '#{t[:name]}' =>  '#{t.to_yaml.gsub('!ruby/sym ','')}'.")
-        trans = L23network.sanitize_transformation(t, default_provider)
+        trans = L23network.sanitize_transformation(t)
         #debug("TTT: '#{trans[:name]}' =>  '#{trans.to_yaml.gsub('!ruby/sym ','')}'.")
 
         # merge interface properties with transformations and vendor_specific
@@ -370,6 +370,15 @@ Puppet::Parser::Functions::newfunction(:generate_network_config, :type => :rvalu
             if trans[:mtu].nil?
               trans[:mtu] = L23network.get_property_for_transformation('MTU', devices[0], lookupvar('l3_fqdn_hostname'))
             end
+          end
+        end
+
+        if !trans[:provider]
+          if action == :port && trans[:bridge]
+            provider = L23network.get_property_for_transformation('PROVIDER', trans[:bridge], lookupvar('l3_fqdn_hostname'))
+            trans[:provider] = provider || default_provider
+          else
+            trans[:provider] = default_provider
           end
         end
 

--- a/lib/puppetx/l23_network_scheme.rb
+++ b/lib/puppetx/l23_network_scheme.rb
@@ -84,6 +84,12 @@ module L23network
           end
         end
         rv = (mtu.empty?  ?  nil  :  mtu.min()  )
+      when 'PROVIDER'
+        transformations.each do |transform|
+          if transform[:name] == trans_name and transform[:provider] != nil
+            rv = transform[:provider]
+          end
+        end
       else
         rv = nil
     end

--- a/spec/functions/get_transformation_property__spec.rb
+++ b/spec/functions/get_transformation_property__spec.rb
@@ -124,6 +124,14 @@ end
       should run.with_params('mtu', 'eth3').and_return(nil)
     end
 
+    it 'should return ovs for "br-floating" transformation' do
+      should run.with_params('provider', 'br-floating').and_return('ovs')
+    end
+
+    it 'should return NIL for "br-storage" transformation' do
+      should run.with_params('provider', 'br-storage').and_return(nil)
+    end
+
   end
 
 end


### PR DESCRIPTION
If Port provider is not specified and Bridge provider is OVS, we need to
use OVS provider for Port instead of default one. Otherwise,
L23_stored_config would choose wrong provider.

FUEL-Change-Id: I1213b70be19b6ce7324d69b1763d4bfd900fe3d9
FUEL-Closes-Bug: #1555162

Closes: #277