### PR TITLE
Add workaround for import puppetx::* from parser functions

### DIFF
--- a/lib/puppet/parser/functions/get_nic_passthrough_whitelist.rb
+++ b/lib/puppet/parser/functions/get_nic_passthrough_whitelist.rb
@@ -1,5 +1,10 @@
-require 'puppetx/l23_network_scheme'
-
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
+#
 Puppet::Parser::Functions::newfunction(:get_nic_passthrough_whitelist, :type => :rvalue, :arity => 1, :doc => <<-EOS
     This function gets pci_passthrough_whitelist mapping from transformations
     Returns NIL if no transformations with this provider found or list


### PR DESCRIPTION
in the Puppet-master mode.

FUEL-Change-Id: Id5dac8fbf71c96a6705a735e711eb5032319896f
FUEL-Closes-Bug: #1544040

Closes: #281