### PR TITLE
Add ability for override transformations into network_scheme.

### DIFF
--- a/lib/puppet/parser/functions/generate_network_config.rb
+++ b/lib/puppet/parser/functions/generate_network_config.rb
@@ -353,10 +353,11 @@ Puppet::Parser::Functions::newfunction(:generate_network_config, :type => :rvalu
         action = t[:action].to_sym()
       end
 
+      #debug("TXX: '#{t[:name]}' =>  '#{t.to_yaml.gsub('!ruby/sym ','')}'.")
+      trans = L23network.sanitize_transformation(t)
+
       if action != :noop
 
-        #debug("TXX: '#{t[:name]}' =>  '#{t.to_yaml.gsub('!ruby/sym ','')}'.")
-        trans = L23network.sanitize_transformation(t)
         #debug("TTT: '#{trans[:name]}' =>  '#{trans.to_yaml.gsub('!ruby/sym ','')}'.")
 
         # merge interface properties with transformations and vendor_specific

--- a/lib/puppet/parser/functions/override_transformations.rb
+++ b/lib/puppet/parser/functions/override_transformations.rb
@@ -1,0 +1,24 @@
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
+
+module Puppet::Parser::Functions
+  newfunction(:override_transformations, :type => :rvalue, :doc => <<-EOS
+    This function get network_scheme, and override transformations.
+    This way is a workaround, because hiera_hash() function glue arrays inside hashes
+    instead override.
+
+    EOS
+  ) do |argv|
+    if !argv[0].is_a? Hash or argv.size != 1
+      raise(Puppet::ParseError, "override_transformations(hash): Wrong number of arguments or argument type.")
+    end
+
+    return L23network.override_transformations(argv[0])
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppet/parser/functions/prepare_network_config.rb
+++ b/lib/puppet/parser/functions/prepare_network_config.rb
@@ -25,6 +25,7 @@ module Puppet::Parser::Functions
     cfg_hash = argv[0]
     Puppet::Parser::Functions.autoloader.loadall
     rv = L23network.sanitize_bool_in_hash(L23network.sanitize_keys_in_hash(cfg_hash))
+    rv = L23network.override_transformations(rv)
     L23network::Scheme.set_config(lookupvar('l3_fqdn_hostname'), rv)
     return true
   end

--- a/lib/puppetx/l23_network_scheme.rb
+++ b/lib/puppetx/l23_network_scheme.rb
@@ -95,5 +95,26 @@ module L23network
     end
     return rv
   end
+
+  def self.override_transformations(network_scheme)
+    org_tranformations = network_scheme.fetch(:transformations,[])
+    transformations = org_tranformations.reject{|x| x[:action]=='override'}
+    org_tranformations.select{|x| x[:action]=='override'}.each do |ov|
+      next if ov[:override].nil?
+      tr_index = transformations.index{|x| x[:name]==ov[:override]}
+      next if tr_index.nil?
+      ov.reject{|k,v| [:override, :action].include? k}.each do |k,v|
+        if k == :'override-action' and v.to_s!=''
+          transformations[tr_index][:action] = v
+        elsif v == ''
+          transformations[tr_index].delete(k)
+        else
+          transformations[tr_index][k] = v
+        end
+      end
+    end
+    network_scheme[:transformations] = transformations
+    return network_scheme
+  end
 end
 # vim: set ts=2 sw=2 et :

--- a/spec/functions/override_transformations__spec.rb
+++ b/spec/functions/override_transformations__spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require 'yaml'
+
+describe 'override_transformations' do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  before :each do
+    #setup_scope
+    puppet_debug_override
+  end
+
+  it 'should exist' do
+    Puppet::Parser::Functions.function('override_transformations').should == 'function_override_transformations'
+  end
+
+  it 'should has ability to override existing fields and add new' do
+    expect(scope.function_override_transformations([{
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0' } ,
+        { :action   => 'add-br',
+          :name     => 'br1',
+          :provider => 'ovs' } ,
+        { :action   => 'override',
+          :override => 'br0',
+          :provider => 'xxx' },
+        { :action   => 'override',
+          :override => 'br1',
+          :provider => 'lnx' }
+      ]
+    }])).to eq({
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0',
+          :provider => 'xxx' },
+        { :action   => 'add-br',
+          :name     => 'br1',
+          :provider => 'lnx' },
+      ]
+    })
+  end
+
+  it 'should has ability to remove existing fields' do
+    expect(scope.function_override_transformations([{
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0' } ,
+        { :action   => 'add-br',
+          :name     => 'br1',
+          :provider => 'ovs' } ,
+        { :action   => 'override',
+          :override => 'br0',
+          :provider => '' },
+        { :action   => 'override',
+          :override => 'br1',
+          :provider => '' }
+      ]
+    }])).to eq({
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0'},
+        { :action   => 'add-br',
+          :name     => 'br1' }
+      ]
+    })
+  end
+
+  it 'should has ability to change name and actions' do
+    expect(scope.function_override_transformations([{
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0' } ,
+        { :action   => 'add-br',
+          :name     => 'br1' } ,
+        { :action   => 'override',
+          :override => 'br0',
+          :name     => 'br0-new' },
+        { :action   => 'override',
+          :override => 'br1',
+          :'override-action' => 'noop' }
+      ]
+    }])).to eq({
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0-new'},
+        { :action   => 'noop',
+          :name     => 'br1' }
+      ]
+    })
+  end
+
+end
+# vim: set ts=2 sw=2 et :


### PR DESCRIPTION
New type of transformation 'override' was added, because hiera_hash()
function does not allow to override arrays. Arrays merged instead replace.

also fix sanitize_transformation for 'noop' transformations

FUEL-Change-Id: Ic4c9c6c34d9e3a57392446b534d997666578d110
FUEL-Related-bug: #1582898

Closes: #285