### PR TITLE
Handle ovs_socket_mem as list

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,9 @@ class l23network::params {
       $ovs_kern_module_name      = 'openvswitch'
       $network_manager_name      = 'network-manager'
       $extra_tools               = 'iputils-arping'
+      $ovs_core_mask             = 0x1
+      $ovs_socket_mem            = [256]
+      $ovs_memory_channels       = 2
     }
     /(?i)redhat|centos|oraclelinux/: {
       $interfaces_dir            = '/etc/sysconfig/network-scripts'
@@ -36,6 +39,9 @@ class l23network::params {
       $ovs_kern_module_name      = 'openvswitch'
       $network_manager_name      = 'NetworkManager'
       $extra_tools               = 'iputils'
+      $ovs_core_mask             = 0x1
+      $ovs_socket_mem            = [256]
+      $ovs_memory_channels       = 2
     }
     /(?i)darwin/: {
       $interfaces_dir            = '/tmp/1'
@@ -49,6 +55,9 @@ class l23network::params {
       $ovs_common_package_name   = undef
       $ovs_kern_module_name      = undef
       $network_manager_name      = undef
+      $ovs_core_mask             = undef
+      $ovs_socket_mem            = undef
+      $ovs_memory_channels       = undef
     }
     default: {
       fail("Unsupported OS: ${l23_os}/${::operatingsystem}")

--- a/templates/openvswitch_default_Debian.erb
+++ b/templates/openvswitch_default_Debian.erb
@@ -1,6 +1,6 @@
 /etc/init.d/dpdk start
 
-export DPDK_OPTS="--dpdk -c <%= @ovs_core_mask %> -n <%= @ovs_memory_channels %> --socket-mem <%= @ovs_socket_mem %>"
+export DPDK_OPTS="--dpdk -c <%= @ovs_core_mask %> -n <%= @ovs_memory_channels %> --socket-mem <%= @ovs_socket_mem.join(',') %>"
 
 # LP 1546565
 umask 0000


### PR DESCRIPTION
Due to yaml dump/load incomsistency, string like '1,2,3,4' will be
dumped without quotes and loaded without commas. To fix it, socket
memory per NUMA will be passed as a list.

FUEL-Change-Id: I579c43a0e8a391092f33a755e18b06ef8ed1a62e
FUEL-Closes-Bug: #1587898

Closes: #291