### PR TITLE
Add ability to remove members from endpoints and interfaces hashes

### DIFF
--- a/lib/puppet/parser/functions/prepare_network_config.rb
+++ b/lib/puppet/parser/functions/prepare_network_config.rb
@@ -26,6 +26,7 @@ module Puppet::Parser::Functions
     Puppet::Parser::Functions.autoloader.loadall
     rv = L23network.sanitize_bool_in_hash(L23network.sanitize_keys_in_hash(cfg_hash))
     rv = L23network.override_transformations(rv)
+    rv = L23network.remove_empty_members(rv)
     L23network::Scheme.set_config(lookupvar('l3_fqdn_hostname'), rv)
     return true
   end

--- a/lib/puppet/parser/functions/remove_empty_members.rb
+++ b/lib/puppet/parser/functions/remove_empty_members.rb
@@ -1,0 +1,24 @@
+begin
+  require 'puppetx/l23_network_scheme'
+rescue LoadError => e
+  rb_file = File.join(File.dirname(__FILE__),'..','..','..','puppetx','l23_network_scheme.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
+
+module Puppet::Parser::Functions
+  newfunction(:remove_empty_members, :type => :rvalue, :doc => <<-EOS
+    This function get network_scheme, and remove empty members (who is an empty string)
+    from endpoints and interfaces.
+    This way is a workaround, because hierahas no ability for remove key from hash.
+
+    EOS
+  ) do |argv|
+    if !argv[0].is_a? Hash or argv.size != 1
+      raise(Puppet::ParseError, "remove_empty_members(hash): Wrong number of arguments or argument type.")
+    end
+
+    return L23network.remove_empty_members(argv[0])
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/lib/puppetx/l23_network_scheme.rb
+++ b/lib/puppetx/l23_network_scheme.rb
@@ -116,5 +116,11 @@ module L23network
     network_scheme[:transformations] = transformations
     return network_scheme
   end
+
+  def self.remove_empty_members(network_scheme)
+    network_scheme[:endpoints] = network_scheme[:endpoints].is_a?(Hash)  ?  network_scheme[:endpoints].reject{|k,v| !v.is_a?(Hash)}  :  {}
+    network_scheme[:interfaces] = network_scheme[:interfaces].is_a?(Hash)  ?  network_scheme[:interfaces].reject{|k,v| !v.is_a?(Hash)}  :  {}
+    return network_scheme
+  end
 end
 # vim: set ts=2 sw=2 et :

--- a/spec/functions/remove_empty_members__spec.rb
+++ b/spec/functions/remove_empty_members__spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'yaml'
+
+describe 'remove empty interfaces and endpoints' do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  before :each do
+    puppet_debug_override
+  end
+
+  it 'should exist' do
+    Puppet::Parser::Functions.function('remove_empty_members').should == 'function_remove_empty_members'
+  end
+
+  it 'should has ability to remove empty keys from config hashes' do
+    expect(scope.function_remove_empty_members([{
+      :endpoints => {
+        :"br-fw-admin"=>
+          {"IP"=>["10.88.0.7/24"],
+           "gateway"=>"",
+           "vendor_specific"=>{"provider_gateway"=>"10.88.0.2"}},
+         "br-mesh"=>""
+      },
+      :interfaces=> {
+          "enp0s3"=>{"vendor_specific"=>{"bus_info"=>"0000:00:03.0", "driver"=>"e1000"}},
+          "enp0s4"=> ""
+      },
+      :provider=>"lnx"
+    }])).to eq({
+      :endpoints => {
+        :"br-fw-admin"=>
+          {"IP"=>["10.88.0.7/24"],
+           "gateway"=>"",
+           "vendor_specific"=>{"provider_gateway"=>"10.88.0.2"}},
+      },
+      :interfaces=> {
+          "enp0s3"=>{"vendor_specific"=>{"bus_info"=>"0000:00:03.0", "driver"=>"e1000"}},
+      },
+      :provider=>"lnx",
+    })
+  end
+
+end
+# vim: set ts=2 sw=2 et :


### PR DESCRIPTION
into network_scheme.

All subhashes into interfaces and endpoints may be overrided by nil
or empty string values.

FUEL-Closes-bug: #1588934
FUEL-Change-Id: I271c17b6fa70cd975fa98a1aa4edd4d7042b0d21

Closes: #294