### PR TITLE
Add ability for override patches in transformations.

### DIFF
--- a/lib/puppetx/l23_network_scheme.rb
+++ b/lib/puppetx/l23_network_scheme.rb
@@ -101,7 +101,13 @@ module L23network
     transformations = org_tranformations.reject{|x| x[:action]=='override'}
     org_tranformations.select{|x| x[:action]=='override'}.each do |ov|
       next if ov[:override].nil?
-      tr_index = transformations.index{|x| x[:name]==ov[:override]}
+      pm = ov[:override].match(/patch-([\w\-]+)\:([\w\-]+)/)
+      if !pm.nil? and pm.size == 3
+        # we should override patch, to search patch use bridge names
+        tr_index = transformations.index{|x| x[:action]=='add-patch' and (x[:bridges]==[pm[1],pm[2]] or x[:bridges]==[pm[2],pm[1]])}
+      else
+        tr_index = transformations.index{|x| x[:name]==ov[:override]}
+      end
       next if tr_index.nil?
       ov.reject{|k,v| [:override, :action].include? k}.each do |k,v|
         if k == :'override-action' and v.to_s!=''

--- a/spec/functions/override_transformations__spec.rb
+++ b/spec/functions/override_transformations__spec.rb
@@ -89,5 +89,40 @@ describe 'override_transformations' do
     })
   end
 
+  it 'should has ability to override "add-patch" action' do
+    expect(scope.function_override_transformations([{
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0' } ,
+        { :action   => 'add-br',
+          :name     => 'br1' } ,
+        { :action   => 'add-br',
+          :name     => 'br2' } ,            # this bridge will be removed by changing action to 'noop'
+        { :action   => 'add-patch',
+          :bridges  => ['br1','br2'] } ,
+        { :action   => 'override',          # override for existing patch
+          :override => 'patch-br1:br2',
+          :bridges  => ['br0','br1'] },
+        { :action   => 'override',          # override for non-existing patch
+          :override => 'patch-br4:br5',
+          :bridges  => ['br0','br1'] },
+        { :action   => 'override',
+          :override => 'br2',
+          :'override-action' => 'noop' }
+      ]
+    }])).to eq({
+      :transformations => [
+        { :action   => 'add-br',
+          :name     => 'br0' } ,
+        { :action   => 'add-br',
+          :name     => 'br1' } ,
+        { :action   => 'noop',
+          :name     => 'br2' } ,
+        { :action   => 'add-patch',
+          :bridges  => ['br0','br1'] }
+      ]
+    })
+  end
+
 end
 # vim: set ts=2 sw=2 et :


### PR DESCRIPTION
for override patches a following syntax should be used:

  - action: override
    override: 'patch-br1:br2'
    bridges: ['new-br1', 'new-br2']

FUEL-Closes-bug: #1590735
FUEL-Change-Id: I89ef5630ab2dfd373b8cd4b7db481278c659db75

Closes: #296