### PR TITLE
Update l2/port.pp vlan interface name regexp.

### DIFF
--- a/manifests/l2/port.pp
+++ b/manifests/l2/port.pp
@@ -72,9 +72,10 @@ define l23network::l2::port (
         }
       }
     }
-    /^([\w\-]+\d+)\.(\d+)/: {
+    /^([\w\-]+\d*)\.(\d+)/: {
       if $vlan_dev == false {
-        # special case for non-vlan devices witn naming like "aaaNNN.XXX"
+        # special case for non-vlan devices witn naming like:
+        # "aaaNNN.XXX", "aaa-NNN.XXX", "aaa-bbb.XXX", "aa-bb-NN.XX"
         $port_vlan_mode = undef
         $port_vlan_id   = undef
         $port_vlan_dev  = undef

--- a/spec/defines/l2_port__spec.rb
+++ b/spec/defines/l2_port__spec.rb
@@ -86,6 +86,45 @@ describe 'l23network::l2::port', :type => :define do
     end
   end
 
+  context 'Native linux bridge subinterface' do
+    let(:params) do
+      {
+        :name => 'br-bm.102',
+      }
+    end
+
+    before(:each) do
+      puppet_debug_override()
+    end
+
+    it do
+      should compile.with_all_deps
+    end
+
+    it do
+      should contain_l23_stored_config('br-bm.102').with({
+        'ensure'    => 'present',
+        'if_type'   => nil,
+        'use_ovs'   => nil,
+        'method'    => nil,
+        'ipaddr'    => nil,
+        'gateway'   => nil,
+        'vlan_id'   => '102',
+        'vlan_dev'  => 'br-bm',
+        'vlan_mode' => 'eth'
+      })
+    end
+
+    it do
+      should contain_l2_port('br-bm.102').with({
+        'ensure'    => 'present',
+        'vlan_id'   => '102',
+        'vlan_dev'  => 'br-bm',
+        'vlan_mode' => 'eth'
+      }).that_requires('L23_stored_config[br-bm.102]')
+    end
+  end
+
   context 'Alternative VLAN definition' do
     let(:params) do
       {


### PR DESCRIPTION
Previously only interfaces with aaaNNN.XXX were recognized as vlan
subinterfaces where NNN and XXX are digits and NNN is required.
It doesn't allow to create vlan subinterfaces with names like
aaa-bbb.XXX.
This patch updates regexp to recognize names like:
aaaNNN.XXX aaa-bbb.XXX aaa.XXX aaa-bbb-NNN.XXX

FUEL-Closes-Bug: #1593142
FUEL-Change-Id: Ic3d97cf5f32cb1107c185fc9ce6c980303e0fc92

Closes: #302