### PR TITLE
Refactor 'get' method for fetch ovs and lnx bridges list

### DIFF
--- a/lib/puppet/provider/l2_bridge/lnx.rb
+++ b/lib/puppet/provider/l2_bridge/lnx.rb
@@ -12,21 +12,14 @@ Puppet::Type.type(:l2_bridge).provide(:lnx, :parent => Puppet::Provider::Lnx_bas
 
   def self.instances
     rv = []
-    get_bridge_list().each_pair do |bridge, props|
-      debug("prefetching '#{bridge}'")
+    get_lnx_bridge_list.each_pair do |bridge, props|
       br_props = {
         :ensure          => :present,
         :name            => bridge,
       }
       br_props.merge! props
-      if props[:br_type] == :lnx
-        #br_props[:provider] = 'lnx'
-        #props[:port_type] = props[:port_type].insert(0, 'ovs').join(':')
-        rv << new(br_props)
-        debug("PREFETCH properties for '#{bridge}': #{br_props}")
-      else
-        debug("SKIP properties for '#{bridge}': #{br_props}")
-      end
+      rv << new(br_props)
+      debug("PREFETCH properties for '#{bridge}': #{br_props}")
     end
     rv
   end
@@ -85,6 +78,13 @@ Puppet::Type.type(:l2_bridge).provide(:lnx, :parent => Puppet::Provider::Lnx_bas
   end
   def stp=(val)
     @property_flush[:stp] = (val.to_s.downcase.to_sym==:true)
+  end
+
+  def members
+    @property_hash[:members] || :absent
+  end
+  def members=(val)
+    @property_flush[:members] # do nothing
   end
 
   #-----------------------------------------------------------------

--- a/lib/puppet/provider/l2_bridge/ovs.rb
+++ b/lib/puppet/provider/l2_bridge/ovs.rb
@@ -96,6 +96,13 @@ Puppet::Type.type(:l2_bridge).provide(:ovs, :parent => Puppet::Provider::Ovs_bas
     @property_flush[:stp] = (val.to_s.downcase.to_sym==:true)
   end
 
+  def members
+    @property_hash[:members] || :absent
+  end
+  def members=(val)
+    @property_flush[:members] # do nothing
+  end
+
   #-----------------------------------------------------------------
 
   def _split(string, splitter=",")

--- a/lib/puppet/provider/l2_port/lnx.rb
+++ b/lib/puppet/provider/l2_port/lnx.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:l2_port).provide(:lnx, :parent => Puppet::Provider::Lnx_base)
       begin
         pkill('-KILL',  '-f', "dhclient.*#{@resource[:interface]}$")
       rescue
-        notice("'#{@resource[:interface]}' does not have any running dhclient processes")
+        debug("'#{@resource[:interface]}' does not have any running dhclient processes")
       end
       #
       # FLUSH changed properties

--- a/lib/puppet/type/l2_bridge.rb
+++ b/lib/puppet/type/l2_bridge.rb
@@ -87,6 +87,17 @@ Puppet::Type.newtype(:l2_bridge) do
       defaultto :false
     end
 
+    newproperty(:members, :array_matching => :all) do
+      desc "Internal read-only property"
+      validate do |value|
+        raise ArgumentError, "You shouldn't change 'members' -- it's a internal RO property! Use 'bridge' for ports, bond, etc... resources."
+      end
+
+      def insync?(value)
+        true
+      end
+    end
+
     newproperty(:vendor_specific) do
       desc "Hash of vendor specific properties"
       #defaultto {}  # no default value should be!!!

--- a/spec/unit/puppet/provider/l2_bridge/lnx_spec.rb
+++ b/spec/unit/puppet/provider/l2_bridge/lnx_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:l2_bridge)
+provider_class = type_class.provider(:lnx)
+
+describe provider_class do
+  let(:resource) do
+    type_class.new(
+        :ensure => 'present',
+        :use_ovs => true,
+        :external_ids => {
+            'bridge-id' => 'br-floating',
+        },
+        :provider => :lnx,
+        :name => 'br-floating',
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:get_lnx_bridge_list) {{
+    'br1' => {
+              :ensure  => :present,
+              :name    => "br1",
+              :members => ["enp2s1"],
+              :stp     => true,
+              :br_type => 'lnx'
+    },
+    'br2' => {
+              :ensure  => :present,
+              :name    => "br2",
+              :members => ["enp2s2"],
+              :stp     => false,
+              :br_type => 'lnx',
+    }
+  }}
+
+  before(:each) do
+    puppet_debug_override()
+  end
+
+  it 'should exists' do
+    expect(provider).not_to be_nil
+  end
+
+  it 'should generate the array on provider instances' do
+    provider_class.stubs(:get_ovs_bridge_list).returns {}
+    provider_class.stubs(:get_lnx_bridge_list).returns get_lnx_bridge_list
+    instances = provider_class.instances
+    expect(instances).to be_a Array
+    expect(instances.length).to eq 2
+    instances.each do |provider|
+      expect(provider).to be_a Puppet::Type::L2_bridge::ProviderLnx
+      class << provider
+          def property_hash
+              @property_hash
+          end
+      end
+    end
+    expect(instances.map { |p| p.property_hash }).to eq([{
+      :ensure   => :present,
+      :name     => "br1",
+      :members  => ['enp2s1'],
+      :stp      => true,
+      :br_type  => "lnx",
+    },{
+      :ensure   => :present,
+      :members  => ['enp2s2'],
+      :name     => "br2",
+      :br_type  => "lnx",
+      :stp      => false,
+    }])
+  end
+
+end


### PR DESCRIPTION
Use /sys/class/net/* filesystem instead parsing of brctl output

FUEL-Change-Id: Iacebc3bcd19e0b5ee43284762f959dec2e4d0308
FUEL-Closes-bug: #1593190

Closes: #306